### PR TITLE
Fixes for multi-parameter spores

### DIFF
--- a/core/src/main/scala/scala/spores/MacroImpl.scala
+++ b/core/src/main/scala/scala/spores/MacroImpl.scala
@@ -1,0 +1,428 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2002-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package scala.spores
+
+import scala.reflect.macros.Context
+
+
+private[spores] class MacroImpl[C <: Context with Singleton](val c: C) {
+  import c.universe._
+
+  def ownerChainContains(sym: Symbol, owner: Symbol): Boolean =
+    sym != null && (sym.owner == owner || {
+      sym.owner != NoSymbol && ownerChainContains(sym.owner, owner)
+    })
+
+  def conforms(funTree: c.Tree): (List[Symbol], Type, Tree, List[Symbol]) = {
+    // traverse body of `fun` and check that the free vars access only allowed things
+    // `validEnv` == symbols declared in the spore header
+    val (validEnv, funLiteral) = funTree match {
+      case Block(stmts, expr) =>
+        val validVarSyms = stmts.toList flatMap {
+          case vd @ ValDef(mods, name, tpt, rhs) =>
+            List(vd.symbol)
+          case stmt =>
+            c.error(stmt.pos, "Only val defs allowed at this position")
+            List()
+        }
+        validVarSyms foreach { sym => debug("valid: " + sym) }
+        (validVarSyms, expr)
+
+      case expr =>
+        (List(), expr)
+    }
+
+    val captureSym = typeOf[spores.`package`.type].member(newTermName("capture"))
+
+    funLiteral match {
+      case fun @ Function(vparams, body) =>
+
+        // contains all symbols found in `capture` syntax
+        var capturedSyms = List[Symbol]()
+
+        // is the use of symbol s allowed via spore rules? (in the spore body)
+        def isSymbolValid(s: Symbol): Boolean =
+          validEnv.contains(s) ||              // is `s` declared in the spore header?
+          capturedSyms.contains(s) ||          // is `s` captured using the `capture` syntax?
+          ownerChainContains(s, fun.symbol) || // is `s` declared within `fun`?
+          s == NoSymbol ||                     // is `s` == `_`?
+          s.isStatic || {
+            c.error(s.pos, "invalid reference to " + s)
+            false
+          }
+
+        // is tree t a path with only components that satisfy pred? (eg stable or lazy)
+        def isPathWith(t: Tree)(pred: TermSymbol => Boolean): Boolean = t match {
+          case sel @ Select(s, _) =>
+            isPathWith(s)(pred) && pred(sel.symbol.asTerm)
+          case id: Ident =>
+            pred(id.symbol.asTerm)
+          case th: This =>
+            true
+          // we can't seem to have a super in paths because of S-1938, pity
+          // https://issues.scala-lang.org/browse/SI-1938
+          // case supr: Super =>
+          //   true
+          case _ =>
+            false
+        }
+
+        // traverse the spore body and collect symbols in `capture` invocations
+        val collectCapturedTraverser = new Traverser {
+          override def traverse(tree: Tree): Unit = tree match {
+            case app @ Apply(fun, List(captured)) if (fun.symbol == captureSym) =>
+              debug("found capture: " + app)
+              if (!isPathWith(captured)(_.isStable))
+                c.error(captured.pos, "Only stable paths can be captured")
+              else if (!isPathWith(captured)(!_.isLazy))
+                c.error(captured.pos, "A captured path cannot contain lazy members")
+              else
+                capturedSyms ::= captured.symbol
+            case _ =>
+              super.traverse(tree)
+          }
+        }
+        debug("collecting captured symbols")
+        collectCapturedTraverser.traverse(body)
+
+        debug(s"checking $body...")
+        // check the spore body, ie for all identifiers, check that they are valid according to spore rules
+        // ie, either declared locally or captured via a `capture` invocation
+        val traverser = new Traverser {
+          override def traverse(tree: Tree) {
+            tree match {
+              case id: Ident =>
+                debug("checking ident " + id)
+                isSymbolValid(id.symbol)
+
+              // x.m().s
+              case sel @ Select(app @ Apply(fun0, args0), _) =>
+                debug("checking select (app): " + sel)
+                if (app.symbol.isStatic) {
+                  debug("OK, fun static")
+                } else fun0 match {
+                  case Select(obj, _) =>
+                    if (ownerChainContains(obj.symbol, fun.symbol)) debug(s"OK, selected on local object $obj")
+                    else c.error(sel.pos, "the fun is not static")
+                  case _ =>
+                    c.error(sel.pos, "the fun is not static")
+                }
+
+              case sel @ Select(pre, _) =>
+                debug("checking select " + sel)
+                if (!sel.symbol.isMethod)
+                  isSymbolValid(sel.symbol)
+
+              case _ =>
+                super.traverse(tree)
+            }
+          }
+        }
+
+        traverser.traverse(body)
+        (vparams.map(_.symbol), body.tpe, body, validEnv)
+
+      case _ =>
+        c.error(funLiteral.pos, "Incorrect usage of `spore`: function literal expected")
+        (null, null, null, validEnv)
+    }
+  }
+
+  def check2(funTree: c.Tree, tpes: List[c.Type]): c.Tree = {
+    debug(s"SPORES: enter check2")
+
+    val (paramSyms, retTpe, funBody, validEnv) = conforms(funTree)
+
+    val applyParamNames = for (i <- 0 until paramSyms.size) yield c.fresh(newTermName("x" + i))
+    val ids = for (name <- applyParamNames.toList) yield Ident(name)
+
+    val applyParamValDefs = for ((applyParamName, paramSym) <- applyParamNames.zip(paramSyms))
+      yield ValDef(Modifiers(Flag.PARAM), applyParamName, TypeTree(paramSym.typeSignature), EmptyTree)
+    val applyParamSymbols = for (applyParamValDef <- applyParamValDefs)
+      yield applyParamValDef.symbol
+
+    def mkApplyDefDef(body: Tree): DefDef = {
+      val applyVParamss = List(applyParamValDefs.toList)
+      DefDef(NoMods, newTermName("apply"), Nil, applyVParamss, TypeTree(retTpe), body)
+    }
+
+    val symtable = c.universe.asInstanceOf[scala.reflect.internal.SymbolTable]
+
+    def processFunctionBody(substituter: symtable.TreeSubstituter, funBody: Tree): DefDef = {
+      val newFunBody = substituter.transform(funBody.asInstanceOf[symtable.Tree])
+      val nfBody     = c.resetLocalAttrs(newFunBody.asInstanceOf[Tree])
+      mkApplyDefDef(nfBody)
+    }
+
+    val sporeClassName = c.fresh(newTypeName("anonspore"))
+
+    if (validEnv.isEmpty) {
+      // replace references to paramSyms with references to applyParamSymbols
+      val substituter = new symtable.TreeSubstituter(paramSyms.map(_.asInstanceOf[symtable.Symbol]), ids.toList.map(_.asInstanceOf[symtable.Tree]))
+      val applyDefDef = processFunctionBody(substituter, funBody)
+
+      if (paramSyms.size == 2) {
+        val rtpe  = tpes(0)
+        val t1tpe = tpes(1)
+        val t2tpe = tpes(2)
+        q"""
+          class $sporeClassName extends scala.spores.Spore2[$t1tpe, $t2tpe, $rtpe] {
+            this._className = this.getClass.getName
+            $applyDefDef
+          }
+          new $sporeClassName
+        """
+      } else if (paramSyms.size == 3) {
+        q"""
+          class $sporeClassName extends scala.spores.Spore3[${tpes(1)}, ${tpes(2)}, ${tpes(3)}, ${tpes(0)}] {
+            this._className = this.getClass.getName
+            $applyDefDef
+          }
+          new $sporeClassName
+        """
+      } else ???
+    } else { // validEnv.size > 1 (TODO: size == 1)
+        // replace references to paramSyms with references to applyParamSymbols
+        // and references to captured variables to new fields
+        val capturedTypes = validEnv.map(_.typeSignature)
+        debug(s"capturedTypes: ${capturedTypes.mkString(",")}")
+
+        val symsToReplace     = (paramSyms ::: validEnv).map(_.asInstanceOf[symtable.Symbol])
+        val newTrees          = (1 to validEnv.size).map(i => Select(Ident(newTermName("captured")), newTermName(s"_$i"))).toList
+        val treesToSubstitute = (ids ::: newTrees).map(_.asInstanceOf[symtable.Tree])
+        val substituter       = new symtable.TreeSubstituter(symsToReplace, treesToSubstitute)
+        val applyDefDef       = processFunctionBody(substituter, funBody)
+
+        val rhss = funTree match {
+          case Block(stmts, expr) =>
+            stmts.toList flatMap {
+              case ValDef(_, _, _, rhs) => List(rhs)
+              case stmt =>
+                c.error(stmt.pos, "Only val defs allowed at this position")
+                List()
+            }
+        }
+
+        val initializerName = c.fresh(newTermName(s"initialize"))
+        val initializerTree = q"$initializerName.captured = (..$rhss)"
+
+        val captureTypeTree = (if (capturedTypes.size == 2) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)})"
+          else if (capturedTypes.size == 3) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)})"
+          else if (capturedTypes.size == 4) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)}, ${capturedTypes(3)})"
+          else if (capturedTypes.size == 5) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)}, ${capturedTypes(3)}, ${capturedTypes(4)})"
+          else if (capturedTypes.size == 6) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)}, ${capturedTypes(3)}, ${capturedTypes(4)}, ${capturedTypes(5)})"
+          else if (capturedTypes.size == 7) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)}, ${capturedTypes(3)}, ${capturedTypes(4)}, ${capturedTypes(5)}, ${capturedTypes(6)})"
+          else if (capturedTypes.size == 8) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)}, ${capturedTypes(3)}, ${capturedTypes(4)}, ${capturedTypes(5)}, ${capturedTypes(6)}, ${capturedTypes(7)})").asInstanceOf[c.Tree]
+
+        if (paramSyms.size == 2) {
+          val rtpe  = tpes(0)
+          val t1tpe = tpes(1)
+          val t2tpe = tpes(2)
+          q"""
+            final class $sporeClassName extends scala.spores.Spore2WithEnv[$t1tpe, $t2tpe, $rtpe] {
+              $captureTypeTree
+              this._className = this.getClass.getName
+              $applyDefDef
+            }
+            val $initializerName = new $sporeClassName
+            $initializerTree
+            $initializerName
+          """
+        } else if (paramSyms.size == 3) {
+          q"""
+            final class $sporeClassName extends scala.spores.Spore3WithEnv[${tpes(1)}, ${tpes(2)}, ${tpes(3)}, ${tpes(0)}] {
+              $captureTypeTree
+              this._className = this.getClass.getName
+              $applyDefDef
+            }
+            val $initializerName = new $sporeClassName
+            $initializerTree
+            $initializerName
+          """
+        } else ???
+    }
+  }
+
+  /**
+     spore {
+       val x = outer
+       (y: T) => { ... }
+     }
+   */
+  def check(funTree: c.Tree, ttpe: c.Type, rtpe: c.Type): c.Tree = {
+    debug(s"SPORES: enter check")
+
+    val (paramSyms, retTpe, funBody, validEnv) = conforms(funTree)
+    val paramSym = paramSyms.head
+
+    if (paramSym != null) {
+      val applyParamName = c.fresh(newTermName("x"))
+      val id = Ident(applyParamName)
+      val applyName = newTermName("apply")
+
+      val applyParamValDef = ValDef(Modifiers(Flag.PARAM), applyParamName, TypeTree(paramSym.typeSignature), EmptyTree)
+      val applyParamSymbol = applyParamValDef.symbol
+
+      val symtable = c.universe.asInstanceOf[scala.reflect.internal.SymbolTable]
+
+      if (validEnv.isEmpty) {
+        // replace reference to paramSym with reference to applyParamSymbol
+        val substituter = new symtable.TreeSubstituter(List(paramSym.asInstanceOf[symtable.Symbol]), List(id.asInstanceOf[symtable.Tree]))
+        val newFunBody = substituter.transform(funBody.asInstanceOf[symtable.Tree])
+
+        val nfBody = c.resetLocalAttrs(newFunBody.asInstanceOf[c.universe.Tree])
+
+        val applyDefDef: DefDef = {
+          val applyVParamss = List(List(applyParamValDef))
+          DefDef(NoMods, applyName, Nil, applyVParamss, TypeTree(retTpe), nfBody)
+        }
+
+        val sporeClassName = c.fresh(newTypeName("anonspore"))
+
+        q"""
+          class $sporeClassName extends scala.spores.Spore[$ttpe, $rtpe] {
+            this._className = this.getClass.getName
+            $applyDefDef
+          }
+          new $sporeClassName
+        """
+      } else if (validEnv.size == 1) { // TODO: simplify
+        // replace reference to paramSym with reference to applyParamSymbol
+        // and references to captured variables to new fields
+        val capturedTypes = validEnv.map(sym => sym.typeSignature)
+        debug(s"capturedTypes: ${capturedTypes.mkString(",")}")
+
+        val fieldNames = (1 to capturedTypes.size).map(i => newTermName(s"c$i")).toList
+        val fieldIds   = fieldNames.map(n => Ident(n))
+
+        val symsToReplace = (paramSym :: validEnv).map(_.asInstanceOf[symtable.Symbol])
+        val idsToSubstitute = (id :: fieldIds).map(_.asInstanceOf[symtable.Tree])
+
+        val substituter = new symtable.TreeSubstituter(symsToReplace, idsToSubstitute)
+        val newFunBody = substituter.transform(funBody.asInstanceOf[symtable.Tree])
+
+        val nfBody = c.resetLocalAttrs(newFunBody.asInstanceOf[c.universe.Tree])
+        val applyDefDef: DefDef = {
+          val applyVParamss = List(List(applyParamValDef))
+          DefDef(NoMods, applyName, Nil, applyVParamss, TypeTree(retTpe), nfBody)
+        }
+
+        val rhss = funTree match {
+          case Block(stmts, expr) =>
+            stmts.toList flatMap { stmt =>
+              stmt match {
+                case vd @ ValDef(mods, name, tpt, rhs) => List(rhs)
+                case _ =>
+                  c.error(stmt.pos, "Only val defs allowed at this position")
+                  List()
+              }
+            }
+        }
+
+        val sporeClassName = c.fresh(newTypeName("anonspore"))
+        val initializerNames = (1 to capturedTypes.size).map(i => c.fresh(newTermName(s"initialize$i")))
+
+        val initializerName = c.fresh(newTermName(s"initialize"))
+        val initializerTrees = fieldNames.zip(rhss).zipWithIndex.map {
+          case ((n, rhs), i) =>
+            val t = newTypeName("C" + (i+1))
+            q"$initializerName.$n = $rhs.asInstanceOf[$initializerName.$t]"
+        }
+
+        val fieldTrees = fieldNames.zipWithIndex.map {
+          case (n, i) =>
+            val t = newTypeName("C" + (i+1))
+            q"var $n: $t = _"
+        }
+
+        val superclassName = newTypeName(s"SporeC${capturedTypes.size}")
+        val captureTypeTree = (if (capturedTypes.size == 1) q"type Captured = ${capturedTypes(0)}"
+          else if (capturedTypes.size == 2) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)})"
+          else if (capturedTypes.size == 3) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)})"
+          else if (capturedTypes.size == 4) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)}, ${capturedTypes(3)})").asInstanceOf[c.Tree]
+
+        val cTypeTrees = capturedTypes.zipWithIndex.map {
+          case (t, i) =>
+            val n = newTypeName("C" + (i + 1))
+            q"type $n = $t"
+        }
+
+        q"""
+          final class $sporeClassName extends $superclassName[$ttpe, $rtpe] {
+            $captureTypeTree
+            ..$cTypeTrees
+            ..$fieldTrees
+            this._className = this.getClass.getName
+            $applyDefDef
+          }
+          val $initializerName = new $sporeClassName
+          ..$initializerTrees
+          $initializerName
+        """
+      } else { // validEnv.size > 1
+        // replace reference to paramSym with reference to applyParamSymbol
+        // and references to captured variables to new fields
+        val capturedTypes = validEnv.map(sym => sym.typeSignature)
+        debug(s"capturedTypes: ${capturedTypes.mkString(",")}")
+
+        val symsToReplace = (paramSym :: validEnv).map(_.asInstanceOf[symtable.Symbol])
+        val newTrees = (1 to validEnv.size).map(i => Select(Ident(newTermName("captured")), newTermName(s"_$i"))).toList
+        val treesToSubstitute = (id :: newTrees).map(_.asInstanceOf[symtable.Tree])
+
+        val substituter = new symtable.TreeSubstituter(symsToReplace, treesToSubstitute)
+        val newFunBody = substituter.transform(funBody.asInstanceOf[symtable.Tree])
+
+        val nfBody = c.resetLocalAttrs(newFunBody.asInstanceOf[c.universe.Tree])
+        val applyDefDef: DefDef = {
+          val applyVParamss = List(List(applyParamValDef))
+          DefDef(NoMods, applyName, Nil, applyVParamss, TypeTree(retTpe), nfBody)
+        }
+
+        val rhss = funTree match {
+          case Block(stmts, expr) =>
+            stmts.toList flatMap { stmt =>
+              stmt match {
+                case vd @ ValDef(mods, name, tpt, rhs) => List(rhs)
+                case _ =>
+                  c.error(stmt.pos, "Only val defs allowed at this position")
+                  List()
+              }
+            }
+        }
+
+        val sporeClassName  = c.fresh(newTypeName("anonspore"))
+        val initializerName = c.fresh(newTermName(s"initialize"))
+        val initializerTree = q"$initializerName.captured = (..$rhss)"
+        val superclassName  = newTypeName(s"SporeWithEnv")
+
+        val captureTypeTree = (if (capturedTypes.size == 2) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)})"
+          else if (capturedTypes.size == 3) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)})"
+          else if (capturedTypes.size == 4) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)}, ${capturedTypes(3)})"
+          else if (capturedTypes.size == 5) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)}, ${capturedTypes(3)}, ${capturedTypes(4)})"
+          else if (capturedTypes.size == 6) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)}, ${capturedTypes(3)}, ${capturedTypes(4)}, ${capturedTypes(5)})"
+          else if (capturedTypes.size == 7) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)}, ${capturedTypes(3)}, ${capturedTypes(4)}, ${capturedTypes(5)}, ${capturedTypes(6)})"
+          else if (capturedTypes.size == 8) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)}, ${capturedTypes(3)}, ${capturedTypes(4)}, ${capturedTypes(5)}, ${capturedTypes(6)}, ${capturedTypes(7)})").asInstanceOf[c.Tree]
+
+        q"""
+          final class $sporeClassName extends $superclassName[$ttpe, $rtpe] {
+            $captureTypeTree
+            this._className = this.getClass.getName
+            $applyDefDef
+          }
+          val $initializerName = new $sporeClassName
+          $initializerTree
+          $initializerName
+        """
+      }
+    } else {
+      ???
+    }
+  }
+
+}

--- a/core/src/main/scala/scala/spores/MacroImpl.scala
+++ b/core/src/main/scala/scala/spores/MacroImpl.scala
@@ -168,11 +168,8 @@ private[spores] class MacroImpl[C <: Context with Singleton](val c: C) {
       val applyDefDef = processFunctionBody(substituter, funBody)
 
       if (paramSyms.size == 2) {
-        val rtpe  = tpes(0)
-        val t1tpe = tpes(1)
-        val t2tpe = tpes(2)
         q"""
-          class $sporeClassName extends scala.spores.Spore2[$t1tpe, $t2tpe, $rtpe] {
+          class $sporeClassName extends scala.spores.Spore2[${tpes(1)}, ${tpes(2)}, ${tpes(0)}] {
             this._className = this.getClass.getName
             $applyDefDef
           }
@@ -221,11 +218,8 @@ private[spores] class MacroImpl[C <: Context with Singleton](val c: C) {
           else if (capturedTypes.size == 8) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)}, ${capturedTypes(3)}, ${capturedTypes(4)}, ${capturedTypes(5)}, ${capturedTypes(6)}, ${capturedTypes(7)})").asInstanceOf[c.Tree]
 
         if (paramSyms.size == 2) {
-          val rtpe  = tpes(0)
-          val t1tpe = tpes(1)
-          val t2tpe = tpes(2)
           q"""
-            final class $sporeClassName extends scala.spores.Spore2WithEnv[$t1tpe, $t2tpe, $rtpe] {
+            final class $sporeClassName extends scala.spores.Spore2WithEnv[${tpes(1)}, ${tpes(2)}, ${tpes(0)}] {
               $captureTypeTree
               this._className = this.getClass.getName
               $applyDefDef

--- a/core/src/main/scala/scala/spores/Spore.scala
+++ b/core/src/main/scala/scala/spores/Spore.scala
@@ -22,8 +22,11 @@ trait Spore[-T, +R] extends Function1[T, R] {
 
   /** Enables creating an instance of a Spore subclass via reflection.
    */
-  def className: String
+  def className: String =
+    _className
 
+  protected[this] var _className: String =
+    null
 }
 
 trait SporeWithEnv[-T, +R] extends Spore[T, R] {
@@ -42,9 +45,63 @@ trait SporeC1[-T, +R] extends SporeWithEnv[T, R] {
   var c1: C1
 }
 
-trait Spore2[-T1, -T2, +R] extends Function2[T1, T2, R]
+trait Spore2[-T1, -T2, +R] extends Function2[T1, T2, R] {
 
-trait Spore3[-T1, -T2, -T3, +R] extends Function3[T1, T2, T3, R]
+  /** The type of captured variables.
+   *
+   *  If this Spore captures multiple variables, this is
+   *  a tuple type.
+   */
+  type Captured
+
+  /** Enables creating an instance of a Spore subclass via reflection.
+   */
+  def className: String =
+    _className
+
+  protected[this] var _className: String =
+    null
+}
+
+trait Spore2WithEnv[-T1, -T2, +R] extends Spore2[T1, T2, R] {
+
+  /** Stores the environment of the Spore.
+   *
+   *  If the Spore captures multiple variables, this field
+   *  stores a tuple.
+   */
+  var captured: Captured = _
+
+}
+
+trait Spore3[-T1, -T2, -T3, +R] extends Function3[T1, T2, T3, R] {
+
+  /** The type of captured variables.
+   *
+   *  If this Spore captures multiple variables, this is
+   *  a tuple type.
+   */
+  type Captured
+
+  /** Enables creating an instance of a Spore subclass via reflection.
+   */
+  def className: String =
+    _className
+
+  protected[this] var _className: String =
+    null
+}
+
+trait Spore3WithEnv[-T1, -T2, -T3, +R] extends Spore3[T1, T2, T3, R] {
+
+  /** Stores the environment of the Spore.
+   *
+   *  If the Spore captures multiple variables, this field
+   *  stores a tuple.
+   */
+  var captured: Captured = _
+
+}
 
 class NullarySporeImpl[+R](val f: () => R) extends NullarySpore[R] {
   def apply(): R = f()
@@ -52,7 +109,7 @@ class NullarySporeImpl[+R](val f: () => R) extends NullarySpore[R] {
 
 class SporeImpl[-T, +R](val f: T => R) extends Spore[T, R] {
   def apply(x: T): R = f(x)
-  def className = "SporeImpl"
+  override def className = "SporeImpl"
 }
 
 class Spore2Impl[-T1, -T2, +R](val f: (T1, T2) => R) extends Spore2[T1, T2, R] {

--- a/spores-pickling/src/main/scala/scala/spores/Pickler.scala
+++ b/spores-pickling/src/main/scala/scala/spores/Pickler.scala
@@ -39,20 +39,21 @@ object SporePickler {
     val picklerUnpicklerName = c.fresh(newTermName("SporePicklerUnpickler"))
     val typeFieldName = """$type"""
 
+    // the problem with the following unpickle method is that it doesn't re-initialize the className field correctly.
     q"""
       val capturedPickler = $cPickler
       val capturedUnpickler = $cUnpickler
-      object $picklerUnpicklerName extends scala.pickling.Pickler[Spore[$ttpe, $rtpe] { type Captured = $utpe }]
-          with scala.pickling.Unpickler[Spore[$ttpe, $rtpe] { type Captured = $utpe }] {
+      object $picklerUnpicklerName extends scala.pickling.Pickler[scala.spores.Spore[$ttpe, $rtpe] { type Captured = $utpe }]
+          with scala.pickling.Unpickler[scala.spores.Spore[$ttpe, $rtpe] { type Captured = $utpe }] {
 
-        def tag: scala.pickling.FastTypeTag[Spore[$ttpe, $rtpe] { type Captured = $utpe }] =
-          implicitly[scala.pickling.FastTypeTag[Spore[$ttpe, $rtpe] { type Captured = $utpe }]]
+        def tag =
+          implicitly[scala.pickling.FastTypeTag[scala.spores.Spore[$ttpe, $rtpe] { type Captured = $utpe }]]
 
-        def pickle(picklee: Spore[$ttpe, $rtpe] { type Captured = $utpe }, builder: PBuilder): Unit = {
+        def pickle(picklee: scala.spores.Spore[$ttpe, $rtpe] { type Captured = $utpe }, builder: scala.pickling.PBuilder): Unit = {
           builder.beginEntry(picklee)
 
           builder.putField("className", b => {
-            b.hintTag(implicitly[FastTypeTag[String]])
+            b.hintTag(scala.pickling.FastTypeTag.String)
             b.hintStaticallyElidedType()
             scala.pickling.pickler.AllPicklers.stringPickler.pickle(picklee.className, b)
           })
@@ -66,9 +67,9 @@ object SporePickler {
           builder.endEntry()
         }
 
-        def unpickle(tag: String, reader: PReader): Any = {
+        def unpickle(tag: String, reader: scala.pickling.PReader): Any = {
           val reader1 = reader.readField($typeFieldName)
-          reader1.hintTag(implicitly[FastTypeTag[String]])
+          reader1.hintTag(scala.pickling.FastTypeTag.String)
           reader1.hintStaticallyElidedType()
 
           val tag = reader1.beginEntry()
@@ -76,7 +77,7 @@ object SporePickler {
           reader1.endEntry()
 
           val reader2 = reader.readField("className")
-          reader2.hintTag(implicitly[FastTypeTag[String]])
+          reader2.hintTag(scala.pickling.FastTypeTag.String)
           reader2.hintStaticallyElidedType()
 
           val tag2 = reader2.beginEntry()
@@ -113,10 +114,10 @@ object SporePickler {
     import definitions.ArrayClass
 */
 
-  implicit def genSporeNCPickler[T, R](implicit tag: FastTypeTag[Spore[T, R]]): Pickler[Spore[T, R] { val className: String }] =
-    macro genSporeNCPicklerImpl[T, R]
+  implicit def genSimpleSporePickler[T, R]: Pickler[Spore[T, R]] =
+    macro genSimpleSporePicklerImpl[T, R]
 
-  def genSporeNCPicklerImpl[T: c.WeakTypeTag, R: c.WeakTypeTag](c: Context)(tag: c.Tree): c.Tree = {
+  def genSimpleSporePicklerImpl[T: c.WeakTypeTag, R: c.WeakTypeTag](c: Context): c.Tree = {
     import c.universe._
 
     val ttpe = weakTypeOf[T]
@@ -126,12 +127,12 @@ object SporePickler {
     val picklerName = c.fresh(newTermName("SporePickler"))
 
     q"""
-      object $picklerName extends scala.pickling.Pickler[Spore[$ttpe, $rtpe] { val className: String }] {
-        def tag: scala.pickling.FastTypeTag[Spore[$ttpe, $rtpe] { val className: String }] =
-          implicitly[scala.pickling.FastTypeTag[Spore[$ttpe, $rtpe] { val className: String }]]
+      object $picklerName extends scala.pickling.Pickler[scala.spores.Spore[$ttpe, $rtpe]] {
+        def tag =
+          implicitly[scala.pickling.FastTypeTag[scala.spores.Spore[$ttpe, $rtpe]]]
 
-        def pickle(picklee: Spore[$ttpe, $rtpe] { val className: String }, builder: PBuilder): Unit = {
-          println("[genSporeNCPicklerImpl]")
+        def pickle(picklee: scala.spores.Spore[$ttpe, $rtpe], builder: scala.pickling.PBuilder): Unit = {
+          println("[genSimpleSporePicklerImpl]")
           builder.beginEntry(picklee)
 
           builder.putField("className", b => {
@@ -147,25 +148,54 @@ object SporePickler {
     """
   }
 
-  implicit def genSimpleSporePickler[T, R]: Pickler[Spore[T, R]] =
-    macro genSimpleSporePicklerImpl[T, R]
+  implicit def genSimpleSpore2Pickler[T1, T2, R]: Pickler[Spore2[T1, T2, R]] =
+    macro genSimpleSpore2PicklerImpl[T1, T2, R]
 
-  def genSimpleSporePicklerImpl[T: c.WeakTypeTag, R: c.WeakTypeTag](c: Context): c.Tree = {
+  def genSimpleSpore2PicklerImpl[T1: c.WeakTypeTag, T2: c.WeakTypeTag, R: c.WeakTypeTag](c: Context): c.Tree = {
     import c.universe._
-
-    val ttpe = weakTypeOf[T]
+    val t1tpe = weakTypeOf[T1]
+    val t2tpe = weakTypeOf[T2]
     val rtpe = weakTypeOf[R]
-
-    debug(s"T: $ttpe, R: $rtpe")
-    val picklerName = c.fresh(newTermName("SporePickler"))
+    val picklerName = c.fresh(newTermName("SimpleSpore2Pickler"))
 
     q"""
-      object $picklerName extends scala.pickling.Pickler[scala.spores.Spore[$ttpe, $rtpe]] {
-        def tag: scala.pickling.FastTypeTag[scala.spores.Spore[$ttpe, $rtpe]] =
-          implicitly[scala.pickling.FastTypeTag[scala.spores.Spore[$ttpe, $rtpe]]]
+      object $picklerName extends scala.pickling.Pickler[scala.spores.Spore2[$t1tpe, $t2tpe, $rtpe]] {
+        def tag =
+          implicitly[scala.pickling.FastTypeTag[scala.spores.Spore2[$t1tpe, $t2tpe, $rtpe]]]
 
-        def pickle(picklee: scala.spores.Spore[$ttpe, $rtpe], builder: PBuilder): Unit = {
-          println("[genSimpleSporePicklerImpl]")
+        def pickle(picklee: scala.spores.Spore2[$t1tpe, $t2tpe, $rtpe], builder: scala.pickling.PBuilder): Unit = {
+          builder.beginEntry(picklee)
+
+          builder.putField("className", b => {
+            b.hintTag(scala.pickling.FastTypeTag.String)
+            b.hintStaticallyElidedType()
+            scala.pickling.pickler.AllPicklers.stringPickler.pickle(picklee.className, b)
+          })
+
+          builder.endEntry()
+        }
+      }
+      $picklerName
+    """
+  }
+
+  implicit def genSimpleSpore3Pickler[T1, T2, T3, R]: Pickler[Spore3[T1, T2, T3, R]] =
+    macro genSimpleSpore3PicklerImpl[T1, T2, T3, R]
+
+  def genSimpleSpore3PicklerImpl[T1: c.WeakTypeTag, T2: c.WeakTypeTag, T3: c.WeakTypeTag, R: c.WeakTypeTag](c: Context): c.Tree = {
+    import c.universe._
+    val t1tpe = weakTypeOf[T1]
+    val t2tpe = weakTypeOf[T2]
+    val t3tpe = weakTypeOf[T3]
+    val rtpe = weakTypeOf[R]
+    val picklerName = c.fresh(newTermName("Spore3Pickler"))
+
+    q"""
+      object $picklerName extends scala.pickling.Pickler[scala.spores.Spore3[$t1tpe, $t2tpe, $t3tpe, $rtpe]] {
+        def tag =
+          implicitly[scala.pickling.FastTypeTag[scala.spores.Spore3[$t1tpe, $t2tpe, $t3tpe, $rtpe]]]
+
+        def pickle(picklee: scala.spores.Spore3[$t1tpe, $t2tpe, $t3tpe, $rtpe], builder: scala.pickling.PBuilder): Unit = {
           builder.beginEntry(picklee)
 
           builder.putField("className", b => {
@@ -185,7 +215,7 @@ object SporePickler {
   // capture > 1 variables
   implicit def genSporeCMPickler[T, R, U <: Product](implicit tag: FastTypeTag[Spore[T, R]], format: PickleFormat,
                                                               cPickler: Pickler[U], cUnpickler: Unpickler[U], cTag: FastTypeTag[U])
-        : Pickler[SporeWithEnv[T, R] { type Captured = U; val className: String }] = macro genSporeCMPicklerImpl[T, R, U]
+        : Pickler[SporeWithEnv[T, R] { type Captured = U }] = macro genSporeCMPicklerImpl[T, R, U]
 
   def genSporeCMPicklerImpl[T: c.WeakTypeTag, R: c.WeakTypeTag, U: c.WeakTypeTag]
         (c: Context)(tag: c.Tree, format: c.Tree, cPickler: c.Tree, cUnpickler: c.Tree, cTag: c.Tree): c.Tree = {
@@ -220,18 +250,18 @@ object SporePickler {
     q"""
       val capturedPickler = $cPickler
       val capturedUnpickler = $cUnpickler
-      object $picklerUnpicklerName extends scala.pickling.Pickler[SporeWithEnv[$ttpe, $rtpe] { type Captured = $utpe; val className: String }]
-          with scala.pickling.Unpickler[SporeWithEnv[$ttpe, $rtpe] { type Captured = $utpe; val className: String }] {
+      object $picklerUnpicklerName extends scala.pickling.Pickler[scala.spores.SporeWithEnv[$ttpe, $rtpe] { type Captured = $utpe }]
+          with scala.pickling.Unpickler[scala.spores.SporeWithEnv[$ttpe, $rtpe] { type Captured = $utpe }] {
 
-        def tag: scala.pickling.FastTypeTag[SporeWithEnv[$ttpe, $rtpe] { type Captured = $utpe; val className: String }] =
-          implicitly[scala.pickling.FastTypeTag[SporeWithEnv[$ttpe, $rtpe] { type Captured = $utpe; val className: String }]]
+        def tag =
+          implicitly[scala.pickling.FastTypeTag[scala.spores.SporeWithEnv[$ttpe, $rtpe] { type Captured = $utpe }]]
 
-        def pickle(picklee: SporeWithEnv[$ttpe, $rtpe] { type Captured = $utpe; val className: String }, builder: PBuilder): Unit = {
-          println("[genSporeCMPicklerImpl]")
+        def pickle(picklee: scala.spores.SporeWithEnv[$ttpe, $rtpe] { type Captured = $utpe }, builder: scala.pickling.PBuilder): Unit = {
+          // println("[genSporeCMPicklerImpl]")
           builder.beginEntry(picklee)
 
           builder.putField("className", b => {
-            b.hintTag(implicitly[FastTypeTag[String]])
+            b.hintTag(scala.pickling.FastTypeTag.String)
             b.hintStaticallyElidedType()
             scala.pickling.pickler.AllPicklers.stringPickler.pickle(picklee.className, b)
           })
@@ -245,9 +275,9 @@ object SporePickler {
           builder.endEntry()
         }
 
-        def unpickle(tag: String, reader: PReader): Any = {
+        def unpickle(tag: String, reader: scala.pickling.PReader): Any = {
           val reader1 = reader.readField($typeFieldName)
-          reader1.hintTag(implicitly[FastTypeTag[String]])
+          reader1.hintTag(scala.pickling.FastTypeTag.String)
           reader1.hintStaticallyElidedType()
 
           val tag = reader1.beginEntry()
@@ -255,14 +285,14 @@ object SporePickler {
           reader1.endEntry()
 
           val reader2 = reader.readField("className")
-          reader2.hintTag(implicitly[FastTypeTag[String]])
+          reader2.hintTag(scala.pickling.FastTypeTag.String)
           reader2.hintStaticallyElidedType()
 
           val tag2 = reader2.beginEntry()
           val result = scala.pickling.pickler.AllPicklers.stringPickler.unpickle(tag2, reader2)
           reader2.endEntry()
 
-          println("[genSporeCMPicklerImpl] creating instance of class " + result)
+          // println("[genSporeCMPicklerImpl] creating instance of class " + result)
           val clazz = java.lang.Class.forName(result.asInstanceOf[String])
           val sporeInst = scala.concurrent.util.Unsafe.instance.allocateInstance(clazz).asInstanceOf[$sporeTypeName[$ttpe, $rtpe] { type Captured = $utpe }]
 
@@ -281,6 +311,124 @@ object SporePickler {
     """
   }
 
+  // capture > 1 variables
+  implicit def genSpore2CMPickler[T1, T2, R, U <: Product](implicit cTag: FastTypeTag[U], cPickler: Pickler[U], cUnpickler: Unpickler[U])
+        : Pickler[Spore2WithEnv[T1, T2, R] { type Captured = U }] = macro genSpore2CMPicklerImpl[T1, T2, R, U]
+
+  def genSpore2CMPicklerImpl[T1: c.WeakTypeTag, T2: c.WeakTypeTag, R: c.WeakTypeTag, U: c.WeakTypeTag]
+        (c: Context)(cTag: c.Tree, cPickler: c.Tree, cUnpickler: c.Tree): c.Tree = {
+    import c.universe._
+    import definitions.ArrayClass
+
+    val t1tpe = weakTypeOf[T1]
+    val t2tpe = weakTypeOf[T2]
+    val rtpe = weakTypeOf[R]
+    val utpe = weakTypeOf[U]
+
+    def isEffectivelyPrimitive(tpe: c.Type): Boolean = tpe match {
+      case TypeRef(_, sym: ClassSymbol, _) if sym.isPrimitive => true
+      case TypeRef(_, sym, eltpe :: Nil) if sym == ArrayClass && isEffectivelyPrimitive(eltpe) => true
+      case _ => false
+    }
+
+    //TODO: check if U is a tuple
+
+    val numVarsCaptured = utpe.typeArgs.size
+    // println(s"numVarsCaptured = $numVarsCaptured")
+    val picklerName = c.fresh(newTermName("Spore2CMPickler"))
+    val typeFieldName = """$type"""
+
+    q"""
+      val capturedPickler = $cPickler
+      val capturedUnpickler = $cUnpickler
+      object $picklerName extends scala.pickling.Pickler[scala.spores.Spore2WithEnv[$t1tpe, $t2tpe, $rtpe] { type Captured = $utpe }] {
+
+        def tag =
+          implicitly[scala.pickling.FastTypeTag[scala.spores.Spore2WithEnv[$t1tpe, $t2tpe, $rtpe] { type Captured = $utpe }]]
+
+        def pickle(picklee: scala.spores.Spore2WithEnv[$t1tpe, $t2tpe, $rtpe] { type Captured = $utpe }, builder: scala.pickling.PBuilder): Unit = {
+          // println("[genSpore2CMPicklerImpl]")
+          builder.beginEntry(picklee)
+
+          builder.putField("className", b => {
+            b.hintTag(scala.pickling.FastTypeTag.String)
+            b.hintStaticallyElidedType()
+            scala.pickling.pickler.AllPicklers.stringPickler.pickle(picklee.className, b)
+          })
+
+          builder.putField("captured", b => {
+            b.hintTag($cTag)
+            ${if (isEffectivelyPrimitive(utpe)) q"b.hintStaticallyElidedType()" else q""}
+            capturedPickler.pickle(picklee.asInstanceOf[scala.spores.Spore2WithEnv[$t1tpe, $t2tpe, $rtpe]].captured.asInstanceOf[$utpe], b)
+          })
+
+          builder.endEntry()
+        }
+      }
+      $picklerName
+    """
+  }
+
+  // capture > 1 variables
+  implicit def genSpore3CMPickler[T1, T2, T3, R, U <: Product](implicit cPickler: Pickler[U], cUnpickler: Unpickler[U])
+        : Pickler[Spore3WithEnv[T1, T2, T3, R] { type Captured = U }] = macro genSpore3CMPicklerImpl[T1, T2, T3, R, U]
+
+  def genSpore3CMPicklerImpl[T1: c.WeakTypeTag, T2: c.WeakTypeTag, T3: c.WeakTypeTag, R: c.WeakTypeTag, U: c.WeakTypeTag]
+        (c: Context)(cPickler: c.Tree, cUnpickler: c.Tree): c.Tree = {
+    import c.universe._
+    import definitions.ArrayClass
+
+    val t1tpe = weakTypeOf[T1]
+    val t2tpe = weakTypeOf[T2]
+    val t3tpe = weakTypeOf[T3]
+    val rtpe = weakTypeOf[R]
+    val utpe = weakTypeOf[U]
+
+    def isEffectivelyPrimitive(tpe: c.Type): Boolean = tpe match {
+      case TypeRef(_, sym: ClassSymbol, _) if sym.isPrimitive => true
+      case TypeRef(_, sym, eltpe :: Nil) if sym == ArrayClass && isEffectivelyPrimitive(eltpe) => true
+      case _ => false
+    }
+
+    //TODO: check if U is a tuple
+
+    val numVarsCaptured = utpe.typeArgs.size
+    // println(s"numVarsCaptured = $numVarsCaptured")
+    val picklerName = c.fresh(newTermName("Spore3CMPickler"))
+    val typeFieldName = """$type"""
+
+    // ${if (isEffectivelyPrimitive(utpe)) q"b.hintStaticallyElidedType()" else q""}
+
+    q"""
+      val capturedPickler = $cPickler
+      val capturedUnpickler = $cUnpickler
+      object $picklerName extends scala.pickling.Pickler[scala.spores.Spore3WithEnv[$t1tpe, $t2tpe, $t3tpe, $rtpe] { type Captured = $utpe }] {
+
+        def tag =
+          implicitly[scala.pickling.FastTypeTag[scala.spores.Spore3WithEnv[$t1tpe, $t2tpe, $t3tpe, $rtpe] { type Captured = $utpe }]]
+
+        def pickle(picklee: scala.spores.Spore3WithEnv[$t1tpe, $t2tpe, $t3tpe, $rtpe] { type Captured = $utpe }, builder: scala.pickling.PBuilder): Unit = {
+          // println("[genSpore3CMPicklerImpl]")
+          builder.beginEntry(picklee)
+
+          builder.putField("className", b => {
+            b.hintTag(scala.pickling.FastTypeTag.String)
+            b.hintStaticallyElidedType()
+            scala.pickling.pickler.AllPicklers.stringPickler.pickle(picklee.className, b)
+          })
+
+          builder.putField("captured", b => {
+            b.hintTag(capturedPickler.tag)
+            capturedPickler.pickle(picklee.asInstanceOf[scala.spores.Spore3WithEnv[$t1tpe, $t2tpe, $t3tpe, $rtpe]].captured.asInstanceOf[$utpe], b)
+          })
+
+          builder.endEntry()
+        }
+      }
+      $picklerName
+    """
+  }
+
 
   implicit def genSporeCSUnpickler[T, R]: Unpickler[Spore[T, R]/* { type Captured }*/] =
     macro genSporeCSUnpicklerImpl[T, R]
@@ -294,25 +442,32 @@ object SporePickler {
 
     q"""
       object $unpicklerName extends scala.pickling.Unpickler[scala.spores.Spore[$ttpe, $rtpe]] {
-        def tag: scala.pickling.FastTypeTag[Spore[$ttpe, $rtpe]] =
-          implicitly[scala.pickling.FastTypeTag[Spore[$ttpe, $rtpe]]]
+        def tag =
+          implicitly[scala.pickling.FastTypeTag[scala.spores.Spore[$ttpe, $rtpe]]]
 
-        def unpickle(tag: String, reader: PReader): Any = {
+        def unpickle(tag: String, reader: scala.pickling.PReader): Any = {
           val reader2 = reader.readField("className")
-          reader2.hintTag(implicitly[FastTypeTag[String]])
+          reader2.hintTag(scala.pickling.FastTypeTag.String)
           reader2.hintStaticallyElidedType()
 
           val tag2 = reader2.beginEntry()
-          val result = scala.pickling.pickler.AllPicklers.stringPickler.unpickle(tag2, reader2)
+          val result = scala.pickling.pickler.AllPicklers.stringPickler.unpickle(tag2, reader2).asInstanceOf[String]
           reader2.endEntry()
 
           // println("[genSporeCSUnpicklerImpl] creating instance of class " + result)
-          val clazz = java.lang.Class.forName(result.asInstanceOf[String])
-          val sporeInst = scala.concurrent.util.Unsafe.instance.allocateInstance(clazz).asInstanceOf[Spore[$ttpe, $rtpe]]
+          val clazz = java.lang.Class.forName(result)
+          val sporeInst = (try clazz.newInstance() catch {
+            case t: Throwable =>
+              val inst = scala.concurrent.util.Unsafe.instance.allocateInstance(clazz)
+              val privateClassNameField = clazz.getDeclaredField("_className")
+              privateClassNameField.setAccessible(true)
+              privateClassNameField.set(inst, result)
+              inst
+          }).asInstanceOf[scala.spores.Spore[$ttpe, $rtpe]]
 
           if (sporeInst.isInstanceOf[scala.spores.SporeWithEnv[$ttpe, $rtpe]]) {
-            println("[genSporeCSUnpicklerImpl] spore class is SporeWithEnv")
-            val sporeWithEnvInst = sporeInst.asInstanceOf[SporeWithEnv[$ttpe, $rtpe]]
+            // println("[genSporeCSUnpicklerImpl] spore class is SporeWithEnv")
+            val sporeWithEnvInst = sporeInst.asInstanceOf[scala.spores.SporeWithEnv[$ttpe, $rtpe]]
             val reader3 = reader.readField("captured")
             val tag3 = reader3.beginEntry()
             val value = {
@@ -334,6 +489,127 @@ object SporePickler {
     """
   }
 
+  implicit def genSpore2CSUnpickler[T1, T2, R]: Unpickler[Spore2[T1, T2, R]] =
+    macro genSpore2CSUnpicklerImpl[T1, T2, R]
+
+  def genSpore2CSUnpicklerImpl[T1: c.WeakTypeTag, T2: c.WeakTypeTag, R: c.WeakTypeTag](c: Context): c.Tree = {
+    import c.universe._
+    val t1tpe = weakTypeOf[T1]
+    val t2tpe = weakTypeOf[T2]
+    val rtpe = weakTypeOf[R]
+
+    val unpicklerName = c.fresh(newTermName("Spore2CSUnpickler"))
+
+    q"""
+      object $unpicklerName extends scala.pickling.Unpickler[scala.spores.Spore2[$t1tpe, $t2tpe, $rtpe]] {
+        def tag =
+          implicitly[scala.pickling.FastTypeTag[scala.spores.Spore2[$t1tpe, $t2tpe, $rtpe]]]
+
+        def unpickle(tag: String, reader: scala.pickling.PReader): Any = {
+          val reader2 = reader.readField("className")
+          reader2.hintTag(scala.pickling.FastTypeTag.String)
+          reader2.hintStaticallyElidedType()
+
+          val tag2 = reader2.beginEntry()
+          val result = scala.pickling.pickler.AllPicklers.stringPickler.unpickle(tag2, reader2).asInstanceOf[String]
+          reader2.endEntry()
+
+          // println("[genSporeCSUnpicklerImpl] creating instance of class " + result)
+          val clazz = java.lang.Class.forName(result)
+          val sporeInst = (try clazz.newInstance() catch {
+            case t: Throwable =>
+              val inst = scala.concurrent.util.Unsafe.instance.allocateInstance(clazz)
+              val privateClassNameField = clazz.getDeclaredField("_className")
+              privateClassNameField.setAccessible(true)
+              privateClassNameField.set(inst, result)
+              inst
+          }).asInstanceOf[scala.spores.Spore2[$t1tpe, $t2tpe, $rtpe]]
+
+          if (sporeInst.isInstanceOf[scala.spores.Spore2WithEnv[$t1tpe, $t2tpe, $rtpe]]) {
+            // println("[genSporeCSUnpicklerImpl] spore class is Spore2WithEnv")
+            val sporeWithEnvInst = sporeInst.asInstanceOf[scala.spores.Spore2WithEnv[$t1tpe, $t2tpe, $rtpe]]
+            val reader3 = reader.readField("captured")
+            val tag3 = reader3.beginEntry()
+            val value = {
+              if (reader3.atPrimitive) {
+                reader3.readPrimitive()
+              } else {
+                val unpickler3 = scala.pickling.runtime.RuntimeUnpicklerLookup.genUnpickler(scala.reflect.runtime.currentMirror, tag3)
+                unpickler3.unpickle(tag3, reader3)
+              }
+            }
+            reader3.endEntry()
+            sporeWithEnvInst.captured = value.asInstanceOf[sporeWithEnvInst.Captured]
+          }
+
+          sporeInst
+        }
+      }
+      $unpicklerName
+    """
+  }
+
+  implicit def genSpore2CMUnpickler[T1, T2, R, U]: Unpickler[Spore2WithEnv[T1, T2, R] { type Captured = U }] =
+    macro genSpore2CMUnpicklerImpl[T1, T2, R, U]
+
+  def genSpore2CMUnpicklerImpl[T1: c.WeakTypeTag, T2: c.WeakTypeTag, R: c.WeakTypeTag, U: c.WeakTypeTag](c: Context): c.Tree = {
+    import c.universe._
+    import definitions.ArrayClass
+
+    // println("enter genSporeUnpicklerImpl...")
+
+    val t1tpe = weakTypeOf[T1]
+    val t2tpe = weakTypeOf[T2]
+    val rtpe = weakTypeOf[R]
+    val utpe = weakTypeOf[U]
+
+    def isEffectivelyPrimitive(tpe: c.Type): Boolean = tpe match {
+      case TypeRef(_, sym: ClassSymbol, _) if sym.isPrimitive => true
+      case TypeRef(_, sym, eltpe :: Nil) if sym == ArrayClass && isEffectivelyPrimitive(eltpe) => true
+      case _ => false
+    }
+
+    // debug(s"T: $ttpe, R: $rtpe")
+
+    val unpicklerName = c.fresh(newTermName("Spore2CMUnpickler"))
+    // TODO: the below unpickling method does not correctly restore the spore's _className field
+
+    q"""
+      object $unpicklerName extends scala.pickling.Unpickler[scala.spores.Spore2WithEnv[$t1tpe, $t2tpe, $rtpe] { type Captured = $utpe }] {
+        def tag =
+          implicitly[scala.pickling.FastTypeTag[scala.spores.Spore2WithEnv[$t1tpe, $t2tpe, $rtpe] { type Captured = $utpe }]]
+
+        def unpickle(tag: String, reader: scala.pickling.PReader): Any = {
+          val reader2 = reader.readField("className")
+          reader2.hintTag(scala.pickling.FastTypeTag.String)
+          reader2.hintStaticallyElidedType()
+
+          val tag2 = reader2.beginEntry()
+          val result = scala.pickling.pickler.AllPicklers.stringPickler.unpickle(tag2, reader2)
+          reader2.endEntry()
+
+          // println("creating instance of class " + result)
+          val clazz = java.lang.Class.forName(result.asInstanceOf[String])
+          val sporeInst = scala.concurrent.util.Unsafe.instance.allocateInstance(clazz).asInstanceOf[scala.spores.Spore2WithEnv[$t1tpe, $t2tpe, $rtpe]]
+
+          val reader3 = reader.readField("captured")
+          val tag3 = reader3.beginEntry()
+          val value = {
+            if (reader3.atPrimitive) {
+              reader3.readPrimitive()
+            } else {
+              val unpickler3 = scala.pickling.runtime.RuntimeUnpicklerLookup.genUnpickler(scala.reflect.runtime.currentMirror, tag3)
+              unpickler3.unpickle(tag3, reader3)
+            }
+          }
+          reader3.endEntry()
+          sporeInst.captured = value.asInstanceOf[sporeInst.Captured]
+          sporeInst
+        }
+      }
+      $unpicklerName
+    """
+  }
 
   implicit def genSporeCMUnpickler[T, R, U](implicit format: PickleFormat): Unpickler[Spore[T, R] { type Captured = U }] =
     macro genSporeCMUnpicklerImpl[T, R, U]
@@ -357,24 +633,25 @@ object SporePickler {
     debug(s"T: $ttpe, R: $rtpe")
 
     val unpicklerName = c.fresh(newTermName("SporeUnpickler"))
+    // TODO: the below unpickling method does not correctly restore the spore's _className field
 
     q"""
-      object $unpicklerName extends scala.pickling.Unpickler[Spore[$ttpe, $rtpe] { type Captured = $utpe }] {
-        def tag: scala.pickling.FastTypeTag[Spore[$ttpe, $rtpe] { type Captured = $utpe }] =
-          implicitly[scala.pickling.FastTypeTag[Spore[$ttpe, $rtpe] { type Captured = $utpe }]]
+      object $unpicklerName extends scala.pickling.Unpickler[scala.spores.Spore[$ttpe, $rtpe] { type Captured = $utpe }] {
+        def tag =
+          implicitly[scala.pickling.FastTypeTag[scala.spores.Spore[$ttpe, $rtpe] { type Captured = $utpe }]]
 
-        def unpickle(tag: String, reader: PReader): Any = {
+        def unpickle(tag: String, reader: scala.pickling.PReader): Any = {
           val reader2 = reader.readField("className")
-          reader2.hintTag(implicitly[FastTypeTag[String]])
+          reader2.hintTag(scala.pickling.FastTypeTag.String)
           reader2.hintStaticallyElidedType()
 
           val tag2 = reader2.beginEntry()
           val result = scala.pickling.pickler.AllPicklers.stringPickler.unpickle(tag2, reader2)
           reader2.endEntry()
 
-          println("creating instance of class " + result)
+          // println("creating instance of class " + result)
           val clazz = java.lang.Class.forName(result.asInstanceOf[String])
-          val sporeInst = scala.concurrent.util.Unsafe.instance.allocateInstance(clazz).asInstanceOf[SporeWithEnv[$ttpe, $rtpe]]
+          val sporeInst = scala.concurrent.util.Unsafe.instance.allocateInstance(clazz).asInstanceOf[scala.spores.SporeWithEnv[$ttpe, $rtpe]]
 
           val reader3 = reader.readField("captured")
           val tag3 = reader3.beginEntry()
@@ -395,4 +672,64 @@ object SporePickler {
     """
   }
 
+  implicit def genSpore3CSUnpickler[T1, T2, T3, R]: Unpickler[Spore3[T1, T2, T3, R]] =
+    macro genSpore3CSUnpicklerImpl[T1, T2, T3, R]
+
+  def genSpore3CSUnpicklerImpl[T1: c.WeakTypeTag, T2: c.WeakTypeTag, T3: c.WeakTypeTag, R: c.WeakTypeTag](c: Context): c.Tree = {
+    import c.universe._
+    val t1tpe = weakTypeOf[T1]
+    val t2tpe = weakTypeOf[T2]
+    val t3tpe = weakTypeOf[T3]
+    val rtpe = weakTypeOf[R]
+
+    val unpicklerName = c.fresh(newTermName("Spore3Unpickler"))
+
+    q"""
+      object $unpicklerName extends scala.pickling.Unpickler[scala.spores.Spore3[$t1tpe, $t2tpe, $t3tpe, $rtpe]] {
+        def tag =
+          implicitly[scala.pickling.FastTypeTag[scala.spores.Spore3[$t1tpe, $t2tpe, $t3tpe, $rtpe]]]
+
+        def unpickle(tag: String, reader: scala.pickling.PReader): Any = {
+          val reader2 = reader.readField("className")
+          reader2.hintTag(scala.pickling.FastTypeTag.String)
+          reader2.hintStaticallyElidedType()
+
+          val tag2 = reader2.beginEntry()
+          val result = scala.pickling.pickler.AllPicklers.stringPickler.unpickle(tag2, reader2).asInstanceOf[String]
+          reader2.endEntry()
+
+          // println("[genSporeCSUnpicklerImpl] creating instance of class " + result)
+          val clazz = java.lang.Class.forName(result)
+          val sporeInst = (try clazz.newInstance() catch {
+            case t: Throwable =>
+              val inst = scala.concurrent.util.Unsafe.instance.allocateInstance(clazz)
+              val privateClassNameField = clazz.getDeclaredField("_className")
+              privateClassNameField.setAccessible(true)
+              privateClassNameField.set(inst, result)
+              inst
+          }).asInstanceOf[scala.spores.Spore3[$t1tpe, $t2tpe, $t3tpe, $rtpe]]
+
+          if (sporeInst.isInstanceOf[scala.spores.Spore3WithEnv[$t1tpe, $t2tpe, $t3tpe, $rtpe]]) {
+            // println("[genSporeCSUnpicklerImpl] spore class is Spore3WithEnv")
+            val sporeWithEnvInst = sporeInst.asInstanceOf[scala.spores.Spore3WithEnv[$t1tpe, $t2tpe, $t3tpe, $rtpe]]
+            val reader3 = reader.readField("captured")
+            val tag3 = reader3.beginEntry()
+            val value = {
+              if (reader3.atPrimitive) {
+                reader3.readPrimitive()
+              } else {
+                val unpickler3 = scala.pickling.runtime.RuntimeUnpicklerLookup.genUnpickler(scala.reflect.runtime.currentMirror, tag3)
+                unpickler3.unpickle(tag3, reader3)
+              }
+            }
+            reader3.endEntry()
+            sporeWithEnvInst.captured = value.asInstanceOf[sporeWithEnvInst.Captured]
+          }
+
+          sporeInst
+        }
+      }
+      $unpicklerName
+    """
+  }
 }

--- a/spores-pickling/src/main/scala/scala/spores/PicklerUtils.scala
+++ b/spores-pickling/src/main/scala/scala/spores/PicklerUtils.scala
@@ -1,0 +1,30 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2002-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package scala.spores
+
+import scala.reflect.macros.Context
+
+
+private[spores] class PicklerUtils[C <: Context with Singleton](val c: C) {
+  import c.universe._
+
+  def readClassNameTree(reader: TermName): Tree = {
+    val result = c.fresh(TermName("result"))
+    q"""
+      val reader2 = $reader.readField("className")
+      reader2.hintTag(scala.pickling.FastTypeTag.String)
+      reader2.hintStaticallyElidedType()
+      val tag2 = reader2.beginEntry()
+      val $result = scala.pickling.pickler.AllPicklers.stringPickler.unpickle(tag2, reader2).asInstanceOf[String]
+      reader2.endEntry()
+      $result
+    """
+  }
+
+}

--- a/spores-pickling/src/test/scala/scala/spores/run/pickling/Pickling.scala
+++ b/spores-pickling/src/test/scala/scala/spores/run/pickling/Pickling.scala
@@ -133,6 +133,21 @@ class PicklingSpec {
   }
 
   @Test
+  def `simple pickling of spore with two parameters and two captured variables`() {
+    val v1 = 10
+    val v2 = "hello"
+    val s = spore {
+      val c1 = v1
+      val c2 = v2
+      (x: Int, y: String) => s"args: $x, $y, c1: $c1, c2: $c2"
+    }
+    val res  = s.pickle
+    val up   = res.unpickle[Spore2[Int, String, String]]
+    val res2 = up(5, "hi")
+    assert(res2 == "args: 5, hi, c1: 10, c2: hello")
+  }
+
+  @Test
   def `simple pickling of spore with three parameters`() {
     val s = spore {
       (x: Int, s: String, c: Char) => s"arg1: $x, arg2: $s, arg3: $c"

--- a/spores-pickling/src/test/scala/scala/spores/run/pickling/SelfDescribing.scala
+++ b/spores-pickling/src/test/scala/scala/spores/run/pickling/SelfDescribing.scala
@@ -1,0 +1,104 @@
+package scala.spores
+package run
+package pickling
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.pickling._
+import Defaults._
+
+import SporePickler._
+
+
+final case class SelfDescribing(unpicklerClassName: String, blob: Array[Byte]) {
+  import binary._
+
+  def result(): Any = {
+    val pickle = BinaryPickleArray(blob)
+    val reader = pickleFormat.createReader(pickle)
+
+    val unpicklerInst = try {
+      Class.forName(unpicklerClassName).newInstance().asInstanceOf[Unpickler[Any]]
+    } catch {
+      case _: Throwable =>
+        scala.concurrent.util.Unsafe.instance.allocateInstance(Class.forName(unpicklerClassName)).asInstanceOf[Unpickler[Any]]
+    }
+
+    val typeString = reader.beginEntry()
+    reader.hintTag(unpicklerInst.tag)
+    unpicklerInst.unpickle(unpicklerInst.tag.key, reader)
+  }
+}
+
+@RunWith(classOf[JUnit4])
+class SelfDescribingSpec {
+  import json._
+
+  def mkSelfDesc[T, S](fun: T => S)(implicit pickler: Pickler[Spore[T, S]], unpickler: Unpickler[Spore[T, S]]): SelfDescribing = {
+    // pickle spore
+    val newBuilder = binary.pickleFormat.createBuilder()
+    newBuilder.hintTag(pickler.tag)
+    pickler.asInstanceOf[Pickler[Any]].pickle(fun, newBuilder)
+    val p = newBuilder.result()
+    SelfDescribing(unpickler.getClass.getName, p.value)
+  }
+
+  def mkSelfDesc2[P <: Spore2[_, _, _]](fun: P)(implicit pickler: Pickler[P], unpickler: Unpickler[P]): SelfDescribing = {
+    // pickle spore
+    val newBuilder = binary.pickleFormat.createBuilder()
+    newBuilder.hintTag(pickler.tag)
+    pickler.asInstanceOf[Pickler[Any]].pickle(fun, newBuilder)
+    val p = newBuilder.result()
+    SelfDescribing(unpickler.getClass.getName, p.value)
+  }
+
+  @Test def test(): Unit = {
+    val s: Spore[Int, String] = spore { (x: Int) =>
+      s"x = $x"
+    }
+
+    // println(s"pickling spore ${s.getClass.getName}...")
+    val sd = mkSelfDesc(s)
+    val p = sd.pickle
+    // println(p.value)
+
+    // println(s"unpickling...")
+    val up = p.unpickle[SelfDescribing]
+    val sup = up.result().asInstanceOf[Spore[Int, String]]
+
+    // println(s"res: ${sup(4)}")
+
+    // println(sup.className)
+    assert(sup.className != null)
+  }
+
+  @Test def test2(): Unit = {
+    val maxSize = 20
+
+    val s = spore {
+        val chunkSize = maxSize / 2
+        val chunkIndex = 0
+        (elem: (String, Int), emit: Emitter[String]) =>
+          val cond1 = elem._2 >= chunkIndex * chunkSize
+          val plusOne = chunkIndex+1
+          val cond2 = elem._2 < plusOne * chunkSize
+          if (cond1 && cond2) emit.emit(elem._1)
+    }
+
+    // println(s"pickling spore ${s.getClass.getName}...")
+    val sd = mkSelfDesc2(s)
+    val p = sd.pickle
+    // println(p.value)
+
+    // println(s"unpickling...")
+    val up = p.unpickle[SelfDescribing]
+    val sup = up.result().asInstanceOf[Spore2[(String, Int), Emitter[String], Unit]]
+
+    val testEmitter = new TestEmitter
+    sup(("hello, " -> 0), testEmitter)
+    sup(("world!" -> 9), testEmitter)
+    assert(testEmitter.builder.toString == "hello, world!")
+  }
+}


### PR DESCRIPTION
- Spore unpicklers restore the contents of the `_className` field.
- Applied refactorings.
- Use fully-qualified type names in macros.
- Enable `Spore3` to capture variables.
- Expand tests for `SelfDescribing`.
- Remove a few unnecessary, long type annotations.