### PR TITLE
Fix #4

### DIFF
--- a/core/src/test/scala/scala/spores/neg/basic/BasicNeg.scala
+++ b/core/src/test/scala/scala/spores/neg/basic/BasicNeg.scala
@@ -32,7 +32,7 @@ class NegSpec {
         import scala.spores._
         lazy val v1 = 10
         val s: Spore[Int, Unit] = spore {
-          (x: Int) => println(s"arg: $x, c1: ${capture(v1)}")
+          (x: Int) => println("arg: " + x + ", c1: " + capture(v1))
         }
       """
     }
@@ -47,7 +47,7 @@ class NegSpec {
         }
         import scala.spores._
         val s: Spore[Int, Unit] = spore {
-          (x: Int) => println(s"arg: $x, c1: ${capture(NoLazyValsObj.v1)}")
+          (x: Int) => println("arg: " + x + ", c1: " + capture(NoLazyValsObj.v1))
         }
       """
     }
@@ -63,6 +63,27 @@ class NegSpec {
           (x: Int) =>
             val s1 = outer
             s1 + "!"
+        }
+      """
+    }
+  }
+
+  @Test
+  def testInvalidReference2(): Unit = {
+    expectError("invalid reference") {
+      """
+        import scala.spores._
+        class C {
+          object A {
+            def foo(a: Int, b: Int): Int =
+              a * b * 3
+          }
+          def m(): Unit = {
+            val s = spore {
+              val y = 3
+              (x: Int) => A.foo(x, y)
+            }
+          }
         }
       """
     }

--- a/core/src/test/scala/scala/spores/run/basic/Basic.scala
+++ b/core/src/test/scala/scala/spores/run/basic/Basic.scala
@@ -114,4 +114,13 @@ class StablePathSpec extends SuperTest {
 
     assert(s(42) == "i can haz stable path")
   }
+
+  @Test
+  def testIssue4(): Unit = {
+    val s = spore {
+      val y = 3
+      (x: Int) => x * y
+    }
+    assert(true)
+  }
 }


### PR DESCRIPTION
- Invalid references: use position of use site instead of
  position of definition site in error messages.
- Resolve two warnings related to potentially missing
  interpolators in neg tests.