### PR TITLE
Fix #15 - Pickling spore fails to compile with one captured value

### DIFF
--- a/core/src/main/scala/scala/spores/Spore.scala
+++ b/core/src/main/scala/scala/spores/Spore.scala
@@ -40,11 +40,6 @@ trait SporeWithEnv[-T, +R] extends Spore[T, R] {
 
 }
 
-trait SporeC1[-T, +R] extends SporeWithEnv[T, R] {
-  type C1
-  var c1: C1
-}
-
 trait Spore2[-T1, -T2, +R] extends Function2[T1, T2, R] {
 
   /** The type of captured variables.

--- a/spores-pickling/src/main/scala/scala/spores/Pickler.scala
+++ b/spores-pickling/src/main/scala/scala/spores/Pickler.scala
@@ -39,7 +39,7 @@ object SporePickler {
 
     val numVarsCaptured = utpe.typeArgs.size
     // println(s"numVarsCaptured = $numVarsCaptured")
-    val sporeTypeName = newTypeName("SporeC1")
+    val sporeTypeName = newTypeName("SporeWithEnv")
 
     debug(s"T: $ttpe, R: $rtpe, U: $utpe")
 
@@ -65,10 +65,10 @@ object SporePickler {
             scala.pickling.pickler.AllPicklers.stringPickler.pickle(picklee.className, b)
           })
 
-          builder.putField("c1", b => {
+          builder.putField("captured", b => {
             b.hintTag(capturedPickler.tag)
             ${if (isEffectivelyPrimitive(utpe)) q"b.hintStaticallyElidedType()" else q""}
-            capturedPickler.pickle(picklee.asInstanceOf[$sporeTypeName[$ttpe, $rtpe]].c1.asInstanceOf[$utpe], b)
+            capturedPickler.pickle(picklee.asInstanceOf[$sporeTypeName[$ttpe, $rtpe]].captured.asInstanceOf[$utpe], b)
           })
 
           builder.endEntry()
@@ -94,13 +94,13 @@ object SporePickler {
           val clazz = java.lang.Class.forName(result.asInstanceOf[String])
           val sporeInst = scala.concurrent.util.Unsafe.instance.allocateInstance(clazz).asInstanceOf[$sporeTypeName[$ttpe, $rtpe] { type Captured = $utpe }]
 
-          val reader3 = reader.readField("c1")
+          val reader3 = reader.readField("captured")
           reader3.hintTag(capturedUnpickler.tag)
           ${if (isEffectivelyPrimitive(utpe)) q"reader3.hintStaticallyElidedType()" else q""}
           val tag3 = reader3.beginEntry()
           val result3 = capturedUnpickler.unpickle(tag3, reader3)
           reader3.endEntry()
-          sporeInst.c1 = result3.asInstanceOf[sporeInst.C1]
+          sporeInst.captured = result3.asInstanceOf[sporeInst.Captured]
 
           sporeInst
         }

--- a/spores-pickling/src/test/scala/scala/spores/run/pickling/Pickling.scala
+++ b/spores-pickling/src/test/scala/scala/spores/run/pickling/Pickling.scala
@@ -33,7 +33,7 @@ class PicklingSpec {
     val res = builder.result()
 
     assert(res.value.toString.endsWith("""
-  "c1": 10
+  "captured": 10
 }"""))
 
     val reader = format.createReader(res.asInstanceOf[format.PickleType])
@@ -60,7 +60,7 @@ class PicklingSpec {
     }
 
     assert(res.value.toString.endsWith("""
-      |  "c1": 10
+      |  "captured": 10
       |}""".stripMargin))
   }
 

--- a/spores-pickling/src/test/scala/scala/spores/run/pickling/issue15.scala
+++ b/spores-pickling/src/test/scala/scala/spores/run/pickling/issue15.scala
@@ -1,0 +1,33 @@
+package scala.spores
+package run
+package pickling
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.pickling._
+import Defaults._
+import json._
+
+import SporePickler._
+
+@RunWith(classOf[JUnit4])
+class Issue15Spec {
+  @Test
+  def test(): Unit = {
+    val s = spore {
+      val pre = "hello"
+      l: List[Int] => l.map(x => s"$pre $x")
+    }
+
+    val d = s.pickle
+    assert(d.value.toString.endsWith("""
+      |    "value": "hello"
+      |  }
+      |}""".stripMargin))
+
+    val us = d.unpickle[Spore[List[Int], List[String]]]
+    assert(us(List(1, 2, 3)).toString == "List(hello 1, hello 2, hello 3)")
+  }
+}


### PR DESCRIPTION
Remove obsolete `SporeC1` trait.