### PR TITLE
Resolve deprecation warnings in spores-pickling

### DIFF
--- a/spores-pickling/src/main/scala/scala/spores/PicklerUtils.scala
+++ b/spores-pickling/src/main/scala/scala/spores/PicklerUtils.scala
@@ -8,14 +8,14 @@
 
 package scala.spores
 
-import scala.reflect.macros.Context
+import scala.reflect.macros.blackbox.Context
 
 
 private[spores] class PicklerUtils[C <: Context with Singleton](val c: C) {
   import c.universe._
 
   def readClassNameTree(reader: TermName): Tree = {
-    val result = c.fresh(TermName("result"))
+    val result = c.freshName(TermName("result"))
     q"""
       val reader2 = $reader.readField("className")
       reader2.hintTag(scala.pickling.FastTypeTag.String)

--- a/spores-pickling/src/main/scala/scala/spores/SimpleSporePicklerImpl.scala
+++ b/spores-pickling/src/main/scala/scala/spores/SimpleSporePicklerImpl.scala
@@ -1,0 +1,104 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2002-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package scala.spores
+
+import scala.reflect.macros.blackbox.Context
+
+import scala.pickling._
+
+trait SimpleSporePicklerImpl {
+
+  def genSimpleSporePicklerImpl[T: c.WeakTypeTag, R: c.WeakTypeTag](c: Context): c.Tree = {
+    import c.universe._
+
+    val ttpe = weakTypeOf[T]
+    val rtpe = weakTypeOf[R]
+
+    debug(s"T: $ttpe, R: $rtpe")
+    val picklerName = c.freshName(TermName("SimpleSporePickler"))
+
+    q"""
+      object $picklerName extends scala.pickling.Pickler[scala.spores.Spore[$ttpe, $rtpe]] {
+        def tag =
+          implicitly[scala.pickling.FastTypeTag[scala.spores.Spore[$ttpe, $rtpe]]]
+
+        def pickle(picklee: scala.spores.Spore[$ttpe, $rtpe], builder: scala.pickling.PBuilder): Unit = {
+          builder.beginEntry(picklee)
+
+          builder.putField("className", b => {
+            b.hintTag(scala.pickling.FastTypeTag.String)
+            b.hintStaticallyElidedType()
+            scala.pickling.pickler.AllPicklers.stringPickler.pickle(picklee.className, b)
+          })
+
+          builder.endEntry()
+        }
+      }
+      $picklerName
+    """
+  }
+
+  def genSimpleSpore2PicklerImpl[T1: c.WeakTypeTag, T2: c.WeakTypeTag, R: c.WeakTypeTag](c: Context): c.Tree = {
+    import c.universe._
+    val t1tpe = weakTypeOf[T1]
+    val t2tpe = weakTypeOf[T2]
+    val rtpe = weakTypeOf[R]
+    val picklerName = c.freshName(TermName("SimpleSpore2Pickler"))
+
+    q"""
+      object $picklerName extends scala.pickling.Pickler[scala.spores.Spore2[$t1tpe, $t2tpe, $rtpe]] {
+        def tag =
+          implicitly[scala.pickling.FastTypeTag[scala.spores.Spore2[$t1tpe, $t2tpe, $rtpe]]]
+
+        def pickle(picklee: scala.spores.Spore2[$t1tpe, $t2tpe, $rtpe], builder: scala.pickling.PBuilder): Unit = {
+          builder.beginEntry(picklee)
+
+          builder.putField("className", b => {
+            b.hintTag(scala.pickling.FastTypeTag.String)
+            b.hintStaticallyElidedType()
+            scala.pickling.pickler.AllPicklers.stringPickler.pickle(picklee.className, b)
+          })
+
+          builder.endEntry()
+        }
+      }
+      $picklerName
+    """
+  }
+
+  def genSimpleSpore3PicklerImpl[T1: c.WeakTypeTag, T2: c.WeakTypeTag, T3: c.WeakTypeTag, R: c.WeakTypeTag](c: Context): c.Tree = {
+    import c.universe._
+    val t1tpe = weakTypeOf[T1]
+    val t2tpe = weakTypeOf[T2]
+    val t3tpe = weakTypeOf[T3]
+    val rtpe = weakTypeOf[R]
+    val picklerName = c.freshName(TermName("Spore3Pickler"))
+
+    q"""
+      object $picklerName extends scala.pickling.Pickler[scala.spores.Spore3[$t1tpe, $t2tpe, $t3tpe, $rtpe]] {
+        def tag =
+          implicitly[scala.pickling.FastTypeTag[scala.spores.Spore3[$t1tpe, $t2tpe, $t3tpe, $rtpe]]]
+
+        def pickle(picklee: scala.spores.Spore3[$t1tpe, $t2tpe, $t3tpe, $rtpe], builder: scala.pickling.PBuilder): Unit = {
+          builder.beginEntry(picklee)
+
+          builder.putField("className", b => {
+            b.hintTag(scala.pickling.FastTypeTag.String)
+            b.hintStaticallyElidedType()
+            scala.pickling.pickler.AllPicklers.stringPickler.pickle(picklee.className, b)
+          })
+
+          builder.endEntry()
+        }
+      }
+      $picklerName
+    """
+  }
+
+}


### PR DESCRIPTION
- Spore picklers require only `macros.blackbox.Context`.
- Resolve deprecation warnings in `spores-pickling` project.
- Move `genSimpleSpore*PicklerImpl` methods to separate trait.