### PR TITLE
Made the following changes to Spores:

### DIFF
--- a/core/src/main/scala/scala/spores/MacroImpl.scala
+++ b/core/src/main/scala/scala/spores/MacroImpl.scala
@@ -284,10 +284,9 @@ private[spores] class MacroImpl[C <: Context with Singleton](val c: C) {
             }
         }
 
-        val initializerName = c.freshName(TermName(s"initialize"))
-        val initializerTree = q"$initializerName.captured = (..$rhss)"
+        val constructorParams = List(List(toTuple(rhss)))
 
-        val captureTypeTree = (if (capturedTypes.size == 2) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)})"
+        val captureTypeTreeDefinition = (if (capturedTypes.size == 2) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)})"
           else if (capturedTypes.size == 3) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)})"
           else if (capturedTypes.size == 4) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)}, ${capturedTypes(3)})"
           else if (capturedTypes.size == 5) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)}, ${capturedTypes(3)}, ${capturedTypes(4)})"
@@ -295,27 +294,26 @@ private[spores] class MacroImpl[C <: Context with Singleton](val c: C) {
           else if (capturedTypes.size == 7) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)}, ${capturedTypes(3)}, ${capturedTypes(4)}, ${capturedTypes(5)}, ${capturedTypes(6)})"
           else if (capturedTypes.size == 8) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)}, ${capturedTypes(3)}, ${capturedTypes(4)}, ${capturedTypes(5)}, ${capturedTypes(6)}, ${capturedTypes(7)})").asInstanceOf[c.Tree]
 
-        if (paramSyms.size == 2) {
+        val q"type $_ = $captureTypeTree" = captureTypeTreeDefinition
+
+
+      if (paramSyms.size == 2) {
           q"""
-            final class $sporeClassName extends scala.spores.Spore2WithEnv[${tpes(1)}, ${tpes(2)}, ${tpes(0)}] {
-              $captureTypeTree
+            final class $sporeClassName(val captured: $captureTypeTree) extends scala.spores.Spore2WithEnv[${tpes(1)}, ${tpes(2)}, ${tpes(0)}] {
+              $captureTypeTreeDefinition
               this._className = this.getClass.getName
               $applyDefDef
             }
-            val $initializerName = new $sporeClassName
-            $initializerTree
-            $initializerName
+            new $sporeClassName(...$constructorParams)
           """
         } else if (paramSyms.size == 3) {
           q"""
-            final class $sporeClassName extends scala.spores.Spore3WithEnv[${tpes(1)}, ${tpes(2)}, ${tpes(3)}, ${tpes(0)}] {
-              $captureTypeTree
+            final class $sporeClassName(val captured: $captureTypeTree) extends scala.spores.Spore3WithEnv[${tpes(1)}, ${tpes(2)}, ${tpes(3)}, ${tpes(0)}] {
+              $captureTypeTreeDefinition
               this._className = this.getClass.getName
               $applyDefDef
             }
-            val $initializerName = new $sporeClassName
-            $initializerTree
-            $initializerName
+            new $sporeClassName(...$constructorParams)
           """
         } else ???
     }
@@ -352,14 +350,16 @@ private[spores] class MacroImpl[C <: Context with Singleton](val c: C) {
       debug(s"capturedTypes: ${capturedTypes.mkString(",")}")
 
       // replace references to captured variables with references to new fields
-      val symsToReplace = validEnv.map(_.asInstanceOf[symtable.Symbol])
+      val symsToReplace = validEnv
       val newTrees =
         if (validEnv.size == 1) List(Ident(TermName("captured")))
-        else (1 to validEnv.size).map(i => Select(Ident(TermName("captured")), TermName(s"_$i"))).toList
-      val treesToSubstitute = newTrees.map(_.asInstanceOf[symtable.Tree])
-
-      val substituter = new symtable.TreeSubstituter(symsToReplace, treesToSubstitute)
-      val newFunBody = substituter.transform(funBody.asInstanceOf[symtable.Tree])
+        else (1 to validEnv.size).map(i => Select(Ident( TermName("captured")), TermName(s"_$i"))).toList
+      val treesToSubstitute = newTrees
+      val symsToTrees = symsToReplace.zip(treesToSubstitute).toMap
+      val namesToTrees = symsToReplace.map(_.name.toString).zip(treesToSubstitute).toMap
+      val newFunBody = transformTypes(symsToTrees,
+        namesToTrees
+      ) (funBody)
 
       val nfBody = c.untypecheck(newFunBody.asInstanceOf[c.universe.Tree])
       val applyDefDef = DefDef(NoMods, applyName, Nil, List(List()), TypeTree(retTpe), nfBody)
@@ -377,13 +377,11 @@ private[spores] class MacroImpl[C <: Context with Singleton](val c: C) {
       }
       assert(rhss.size == validEnv.size)
 
-      val initializerName = c.freshName(TermName("initialize"))
-      val initializerTree =
-        if (validEnv.size == 1) q"$initializerName.captured = ${rhss.head}"
-        else q"$initializerName.captured = (..$rhss)"
+      val constructorParams = List(List(toTuple(rhss)))
+
       val superclassName = TypeName("NullarySporeWithEnv")
 
-      val captureTypeTree = (if (capturedTypes.size == 1) q"type Captured = ${capturedTypes(0)}"
+      val captureTypeTreeDefinition = (if (capturedTypes.size == 1) q"type Captured = ${capturedTypes(0)}"
         else if (capturedTypes.size == 2) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)})"
         else if (capturedTypes.size == 3) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)})"
         else if (capturedTypes.size == 4) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)}, ${capturedTypes(3)})"
@@ -392,17 +390,118 @@ private[spores] class MacroImpl[C <: Context with Singleton](val c: C) {
         else if (capturedTypes.size == 7) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)}, ${capturedTypes(3)}, ${capturedTypes(4)}, ${capturedTypes(5)}, ${capturedTypes(6)})"
         else if (capturedTypes.size == 8) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)}, ${capturedTypes(3)}, ${capturedTypes(4)}, ${capturedTypes(5)}, ${capturedTypes(6)}, ${capturedTypes(7)})").asInstanceOf[c.Tree]
 
+      val q"type $_ = $captureTypeTree" = captureTypeTreeDefinition
+
       q"""
-        final class $sporeClassName extends $superclassName[$rtpe] {
-          $captureTypeTree
+        final class $sporeClassName(val captured: $captureTypeTree) extends $superclassName[$rtpe] {
+          $captureTypeTreeDefinition
           this._className = this.getClass.getName
           $applyDefDef
         }
-        val $initializerName = new $sporeClassName
-        $initializerTree
-        $initializerName
+        new $sporeClassName(...$constructorParams)
       """
     }
+  }
+
+  /* Constructs a function that replaces all occurrences of symbols in m with trees in m and that changes the 'origin'
+   * field to fix path-dependent types.
+   */
+  def transformTypes(m: Map[c.universe.Symbol, Tree], nameMap: Map[String, Tree]) : Tree => Tree = {
+
+    // recycled from TreeSubstituter in Trees.scala and
+    // https://github.com/non/spire/blob/master/macros/src/main/scala/spire/macros/Syntax.scala
+    // https://github.com/non/spire/blob/master/macros/src/main/scala_2.11/spire/macros/compat.scala
+    class TypeTransformer(val m: Map[c.universe.Symbol, Tree],
+                          val nameMap: Map[String, Tree]
+                         ) extends Transformer {
+      override def transform(tree: Tree): Tree = {
+
+        tree match {
+          case ident@Ident(_) =>
+            if (m.contains(tree.symbol)) m(tree.symbol)
+            else tree
+          case tt: TypeTree if tt.original != null =>
+            super.transform(c.universe.internal.setOriginal(TypeTree(), super.transform(tt.original)))
+          case tt: TypeTree if tt.original == null =>
+            if (showRaw(tree) == "TypeTree()" &&
+              nameMap.keys.exists( key => s"${tree.tpe}".contains(key.toString))) {
+              debug(s"${showRaw(tree)}")
+              debug(s"${showRaw(tree.tpe)}")
+              debug(s"${tree.tpe}")
+
+
+              def constructOriginal(tp: c.Type) : c.Tree = {
+                // Example: tp =
+                // TypeRef(
+                //   SingleType(
+                //     SingleType(NoPrefix, TermName("lit5_ui")),
+                //     TermName("uref")),
+                //   TypeName("R"),
+                //   List())
+                def matchTypeName(tn: c.Symbol) : c.TypeName =  {
+                  if (showRaw(tn).startsWith("TypeName(")) TypeName(tn.name.toString)
+                  else null
+                }
+                def matchTermNameNoPrefixCase(tn: c.Symbol) : Tree =  {
+                  if (showRaw(tn).startsWith("TermName(")) {
+                    val sym_name = tn.name.toString
+                    if (nameMap.contains(sym_name)) nameMap(sym_name) else Ident(TermName(sym_name))
+                  }
+                  else null
+                }
+
+                def matchTermName(tn: c.Symbol) : TermName =  {
+                  if (showRaw(tn).startsWith("TermName(")) {
+                    TermName(tn.name.toString)
+                  }
+                  else null
+                }
+                tp match {
+                  case TypeRef(tr, tns, List()) =>
+                    debug(s"tns = $tns,\nshowRaw(tns) = ${showRaw(tns)}")
+                    val tnsTypeName = matchTypeName(tns)
+                    if (tnsTypeName != null) {
+                      val tr_rec = constructOriginal(tr)
+                      if (tr_rec != null) Select(tr_rec, tnsTypeName)
+                      else null
+                    }
+                    else null
+                  case SingleType(NoPrefix, tns) =>
+                    matchTermNameNoPrefixCase(tns)
+                  case SingleType(pre, tns) =>
+                    val tnsTypeName = matchTermName(tns)
+                    val pre_rec = constructOriginal(pre)
+                    if (pre_rec != null) Select(pre_rec, tnsTypeName)
+                    else null
+                  case _ => null
+                }
+              }
+
+              val new_orig = constructOriginal(tree.tpe)
+              val res = if (new_orig != null)
+                  c.universe.internal.setOriginal(TypeTree(), new_orig)
+                else
+                  tree
+              res
+            }
+            else tree
+          case _ => super.transform(tree)
+        }
+      }
+    }
+    new TypeTransformer(m, nameMap).transform(_: Tree)
+  }
+
+  def toTuple(lst: List[c.Tree]) : c.Tree = {
+    if (lst.size == 1) lst(0)
+    else if (lst.size == 2) q"(${lst(0)}, ${lst(1)})"
+    else if (lst.size == 3) q"(${lst(0)}, ${lst(1)}, ${lst(2)})"
+    else if (lst.size == 4) q"(${lst(0)}, ${lst(1)}, ${lst(2)}, ${lst(3)})"
+    else if (lst.size == 5) q"(${lst(0)}, ${lst(1)}, ${lst(2)}, ${lst(3)}, ${lst(4)})"
+    else if (lst.size == 6) q"(${lst(0)}, ${lst(1)}, ${lst(2)}, ${lst(3)}, ${lst(4)}, ${lst(5)})"
+    else if (lst.size == 7) q"(${lst(0)}, ${lst(1)}, ${lst(2)}, ${lst(3)}, ${lst(4)}, ${lst(5)}, ${lst(6)})"
+    else if (lst.size == 8) q"(${lst(0)}, ${lst(1)}, ${lst(2)}, ${lst(3)}, ${lst(4)}, ${lst(5)}, ${lst(6)}, ${lst(7)})"
+    else ???
   }
 
   /**
@@ -412,10 +511,11 @@ private[spores] class MacroImpl[C <: Context with Singleton](val c: C) {
      }
    */
   def check(funTree: c.Tree, ttpe: c.Type, rtpe: c.Type): c.Tree = {
-    debug(s"SPORES: enter check")
+    debug(s"SPORES: enter check, tree:\n$funTree")
 
     val (paramSyms, retTpe, funBody, validEnv) = conforms(funTree)
     val paramSym = paramSyms.head
+    val oldName = paramSym.asInstanceOf[c.universe.TermSymbol].name
 
     if (paramSym != null) {
       val applyParamName = c.freshName(TermName("x"))
@@ -423,16 +523,17 @@ private[spores] class MacroImpl[C <: Context with Singleton](val c: C) {
       val applyName = TermName("apply")
 
       val applyParamValDef = ValDef(Modifiers(Flag.PARAM), applyParamName, TypeTree(paramSym.typeSignature), EmptyTree)
-      val applyParamSymbol = applyParamValDef.symbol
 
       val symtable = c.universe.asInstanceOf[scala.reflect.internal.SymbolTable]
       val sporeClassName = c.freshName(TypeName("anonspore"))
 
       if (validEnv.isEmpty) {
-        // replace reference to paramSym with reference to applyParamSymbol
-        val substituter = new symtable.TreeSubstituter(List(paramSym.asInstanceOf[symtable.Symbol]), List(id.asInstanceOf[symtable.Tree]))
-        val newFunBody = substituter.transform(funBody.asInstanceOf[symtable.Tree])
+        val typeTransformer = transformTypes(Map(paramSym -> id),
+          Map(oldName.toString -> id)
+        )
+        val newFunBody = typeTransformer(funBody)
 
+       
         val nfBody = c.untypecheck(newFunBody.asInstanceOf[c.universe.Tree])
 
         val applyDefDef: DefDef = {
@@ -453,14 +554,17 @@ private[spores] class MacroImpl[C <: Context with Singleton](val c: C) {
         val capturedTypes = validEnv.map(_.typeSignature)
         debug(s"capturedTypes: ${capturedTypes.mkString(",")}")
 
-        val symsToReplace = (paramSym :: validEnv).map(_.asInstanceOf[symtable.Symbol])
+        val symsToReplace = paramSym :: validEnv
         val newTrees =
           if (validEnv.size == 1) List(Ident(TermName("captured")))
           else (1 to validEnv.size).map(i => Select(Ident(TermName("captured")), TermName(s"_$i"))).toList
-        val treesToSubstitute = (id :: newTrees).map(_.asInstanceOf[symtable.Tree])
 
-        val substituter = new symtable.TreeSubstituter(symsToReplace, treesToSubstitute)
-        val newFunBody = substituter.transform(funBody.asInstanceOf[symtable.Tree])
+        val treesToSubstitute = id :: newTrees
+        val symsToTrees = symsToReplace.zip(treesToSubstitute).toMap
+        val namesToTrees = symsToReplace.map(_.name.toString).zip(treesToSubstitute).toMap
+        val newFunBody = transformTypes(symsToTrees,
+          namesToTrees
+        ) (funBody)
 
         val nfBody = c.untypecheck(newFunBody.asInstanceOf[c.universe.Tree])
         val applyDefDef: DefDef = {
@@ -482,29 +586,27 @@ private[spores] class MacroImpl[C <: Context with Singleton](val c: C) {
         assert(rhss.size == validEnv.size)
 
         val initializerName = c.freshName(TermName("initialize"))
-        val initializerTree =
-          if (validEnv.size == 1) q"$initializerName.captured = ${rhss.head}"
-          else q"$initializerName.captured = (..$rhss)"
+        val constructorParams = List(List(toTuple(rhss)))
         val superclassName = TypeName("SporeWithEnv")
 
-        val captureTypeTree = (if (capturedTypes.size == 1) q"type Captured = ${capturedTypes(0)}"
-          else if (capturedTypes.size == 2) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)})"
-          else if (capturedTypes.size == 3) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)})"
-          else if (capturedTypes.size == 4) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)}, ${capturedTypes(3)})"
-          else if (capturedTypes.size == 5) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)}, ${capturedTypes(3)}, ${capturedTypes(4)})"
-          else if (capturedTypes.size == 6) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)}, ${capturedTypes(3)}, ${capturedTypes(4)}, ${capturedTypes(5)})"
-          else if (capturedTypes.size == 7) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)}, ${capturedTypes(3)}, ${capturedTypes(4)}, ${capturedTypes(5)}, ${capturedTypes(6)})"
-          else if (capturedTypes.size == 8) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)}, ${capturedTypes(3)}, ${capturedTypes(4)}, ${capturedTypes(5)}, ${capturedTypes(6)}, ${capturedTypes(7)})").asInstanceOf[c.Tree]
+        val capturedTypeDefinition = (if (capturedTypes.size == 1) q"type Captured = ${capturedTypes(0)}"
+        else if (capturedTypes.size == 2) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)})"
+        else if (capturedTypes.size == 3) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)})"
+        else if (capturedTypes.size == 4) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)}, ${capturedTypes(3)})"
+        else if (capturedTypes.size == 5) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)}, ${capturedTypes(3)}, ${capturedTypes(4)})"
+        else if (capturedTypes.size == 6) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)}, ${capturedTypes(3)}, ${capturedTypes(4)}, ${capturedTypes(5)})"
+        else if (capturedTypes.size == 7) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)}, ${capturedTypes(3)}, ${capturedTypes(4)}, ${capturedTypes(5)}, ${capturedTypes(6)})"
+        else if (capturedTypes.size == 8) q"type Captured = (${capturedTypes(0)}, ${capturedTypes(1)}, ${capturedTypes(2)}, ${capturedTypes(3)}, ${capturedTypes(4)}, ${capturedTypes(5)}, ${capturedTypes(6)}, ${capturedTypes(7)})").asInstanceOf[c.Tree]
 
+        val q"type $_ = $capturedTypeTree" = capturedTypeDefinition
+        
         q"""
-          final class $sporeClassName extends $superclassName[$ttpe, $rtpe] {
-            $captureTypeTree
+          class $sporeClassName(val captured : $capturedTypeTree) extends $superclassName[$ttpe, $rtpe] {
+            $capturedTypeDefinition
             this._className = this.getClass.getName
             $applyDefDef
           }
-          val $initializerName = new $sporeClassName
-          $initializerTree
-          $initializerName
+          new $sporeClassName(...$constructorParams)
         """
       }
     } else {

--- a/core/src/main/scala/scala/spores/Spore.scala
+++ b/core/src/main/scala/scala/spores/Spore.scala
@@ -33,7 +33,7 @@ trait NullarySporeWithEnv[+R] extends NullarySpore[R] {
    *  If the Spore captures multiple variables, this field
    *  stores a tuple.
    */
-  var captured: Captured = _
+  val captured: Captured //= _
 
 }
 
@@ -62,7 +62,7 @@ trait SporeWithEnv[-T, +R] extends Spore[T, R] {
    *  If the Spore captures multiple variables, this field
    *  stores a tuple.
    */
-  var captured: Captured = _
+  val captured: Captured // = _
 
 }
 
@@ -91,7 +91,7 @@ trait Spore2WithEnv[-T1, -T2, +R] extends Spore2[T1, T2, R] {
    *  If the Spore captures multiple variables, this field
    *  stores a tuple.
    */
-  var captured: Captured = _
+  val captured: Captured // = _
 
 }
 
@@ -120,7 +120,7 @@ trait Spore3WithEnv[-T1, -T2, -T3, +R] extends Spore3[T1, T2, T3, R] {
    *  If the Spore captures multiple variables, this field
    *  stores a tuple.
    */
-  var captured: Captured = _
+  val captured: Captured // = _
 
 }
 

--- a/core/src/main/scala/scala/spores/package.scala
+++ b/core/src/main/scala/scala/spores/package.scala
@@ -97,13 +97,13 @@ package object spores {
             case vd @ ValDef(mods, name, tpt, rhs) =>
               List(vd.symbol -> tpt.tpe)
             case td @ TypeDef(mods, name, tparams, rhs) =>
-              println(s"found type def $name with rhs: $rhs")
+              debug(s"found type def $name with rhs: $rhs")
               if (name.toString == "Constraint") {
                 rhs match {
                   case tpt @ TypeTree() =>
-                    println(s"found TypeTree, tpe: ${tpt.tpe}")
+                    debug(s"found TypeTree, tpe: ${tpt.tpe}")
                   case _ =>
-                    println(s"rhs is something else: ${rhs.getClass}")
+                    debug(s"rhs is something else: ${rhs.getClass}")
                 }
               }
               List()
@@ -170,7 +170,7 @@ package object spores {
 
     // check Spore constraints
     val tpes = checkTc(c)(fun.tree)
-    println("captured types: " + tpes)
+    debug("captured types: " + tpes)
 
     reify {
       val f = fun.splice

--- a/core/src/test/scala/scala/spores/run/basic/Basic.scala
+++ b/core/src/test/scala/scala/spores/run/basic/Basic.scala
@@ -144,39 +144,7 @@ class BasicSpec {
   }
 
 
-  /**
-    * same as nestedPTTCapture, but (_: Unit) => ... replaced with Nullary spore
-    */
-//  @Test
-//  def nestedPTTCaptureNullary(): Unit = {
-//
-//    abstract class A {
-//      self =>
-//      type B
-//      val t: self.B
-//      def f(x: self.B) = {}
-//    }
-//
-//    val s = spore{
-//      val y = 5
-//      delayed {
-//        spore {
-//          val y = 5
-//          (a: A) => {
-//            val k: a.B = a.t
-//            a.f(k)
-//          }
-//        }
-//        println()
-//      }
-//    }
-//  }
 
-
-
-  /**
-    * Should be the same that SporeAvoided and Spore expands to in Ownership.scala.
-    */
   @Test
   def sporeWithAnonClasses(): Unit = {
 

--- a/core/src/test/scala/scala/spores/run/basic/Basic.scala
+++ b/core/src/test/scala/scala/spores/run/basic/Basic.scala
@@ -23,11 +23,180 @@ package somepackage {
   }
 }
 
+
+
+abstract class X { def g(f: Int => Unit) : Unit}
+abstract class TestCl[T] {val x : X}
+
+
 @RunWith(classOf[JUnit4])
 class BasicSpec {
+
+
+  /**
+    * Test the following:
+    * spore has variable a
+    * a is part of PTT in spore
+    * PTT needs to be correct, when 'a' is changed into x$macro$n,
+    * PTT must change.
+    *
+    * Expansion with SporeConv.sporeConv is optional.
+    */
+  @Test
+  def pTTParameterCapture(): Unit = {
+
+    abstract class A {
+      self =>
+      type B
+      val t: self.B
+      def f(x: self.B) = {}
+    }
+
+    val s = spore{
+      val y = 5
+      (a: A) => {
+        val k: a.B = a.t
+        a.f(k)
+      }
+    }
+  }
+
+  /**
+    * Same as pTTParameterCapture, but
+    * the path-dependent type comes from a captured variable,
+    * not from the parameter
+    */
+  @Test
+  def pTTCapturedCapture(): Unit = {
+
+    abstract class A {
+      self =>
+      type B
+      val t: self.B
+      def f(x: self.B) = {}
+    }
+
+    val s = spore{
+      (a: A) => {
+        val s2 = spore {
+          val na = a
+          (_: Unit) => {
+            val k: na.B = na.t
+            na.f(k)
+          }
+        }
+      }
+    }
+  }
+
+  /**
+    * Same as pTTCapturedCapture, but with nullary spores (more code coverage)
+    */
+  @Test
+  def pTTCapturedCaptureNullary(): Unit = {
+
+    abstract class A {
+      self =>
+      type B
+      val t: self.B
+      def f(x: self.B) = {}
+    }
+
+    val s = spore{
+      (a: A) => {
+        val s2 = spore {
+          val na = a
+          delayed {
+            val k: na.B = na.t
+            na.f(k)
+          }
+        }
+      }
+    }
+  }
+
+  /**
+    * Similar to pTTCapture(), but spores are nested.
+    */
+  @Test
+  def nestedPTTCapture(): Unit = {
+
+    abstract class A {
+      self =>
+      type B
+      val t: self.B
+      def f(x: self.B) = {}
+    }
+
+    val s = spore{
+      val y = 5
+      (_: Unit) => {
+        spore {
+          val y = 5
+          (a: A) => {
+            val k: a.B = a.t
+            a.f(k)
+          }
+        }
+        println()
+      }
+    }
+  }
+
+
+  /**
+    * same as nestedPTTCapture, but (_: Unit) => ... replaced with Nullary spore
+    */
+//  @Test
+//  def nestedPTTCaptureNullary(): Unit = {
+//
+//    abstract class A {
+//      self =>
+//      type B
+//      val t: self.B
+//      def f(x: self.B) = {}
+//    }
+//
+//    val s = spore{
+//      val y = 5
+//      delayed {
+//        spore {
+//          val y = 5
+//          (a: A) => {
+//            val k: a.B = a.t
+//            a.f(k)
+//          }
+//        }
+//        println()
+//      }
+//    }
+//  }
+
+
+
+  /**
+    * Should be the same that SporeAvoided and Spore expands to in Ownership.scala.
+    */
+  @Test
+  def sporeWithAnonClasses(): Unit = {
+
+    class B {self => type C}
+
+    val s = spore{
+      (x: B) => {
+        final class anon { type D = x.C }
+        val y = new anon
+      }
+    }
+  }
+
+
+
+
   @Test
   def `simple spore transformation`(): Unit = {
     val v1 = 10
+    val v2 = 20
     val s: Spore[Int, String] = spore {
       val c1 = v1
       (x: Int) => s"arg: $x, c1: $c1"
@@ -66,6 +235,66 @@ class BasicSpec {
     }
     assert(s(2).contains("C"))
   }
+
+  // This is to test that path-dependent types in which captured arguments are part of the path are
+  // transformed correctly.
+  @Test
+  def pathDependentTypes(): Unit = {
+    class A {
+      type B
+      def f(x: B) = println(x)
+    }
+
+    val s = spore {
+      (x: A) => {
+        x.f(null.asInstanceOf[x.B])
+      }
+    }
+  }
+
+  // This is to test that path-dependent types in which captured arguments are part of the path are
+  // transformed correctly.
+  @Test
+  def pathDependentTypesWithCapture(): Unit = {
+    class A {
+      type B
+      def f(x: B) = println(x)
+    }
+
+    val y = 10
+
+    val s = spore {
+      val yy = y
+      (x: A) => {
+        x.f(null.asInstanceOf[x.B])
+      }
+    }
+  }
+
+  // This is to test that path-dependent types in which captured arguments are part of the path are
+  // transformed correctly.
+  @Test
+  def pathDependentTypesWithNestedSpores(): Unit = {
+    abstract class A {
+      val c: {type B}
+      def f(s: Spore[A, Unit]) = s(this)
+      def g(x: c.B) = println(x)
+    }
+
+    val s = spore {
+      (a: A) => {
+        a.f(spore {
+          val cap_a = a
+          (a1: A) => {
+            val cap_cap_a = cap_a
+            a1.g(null.asInstanceOf[a1.c.B])
+          }
+        })
+      }
+    }
+  }
+
+
 }
 
 

--- a/core/src/test/scala/scala/spores/run/basic/NullaryUnitSporeComparison.scala
+++ b/core/src/test/scala/scala/spores/run/basic/NullaryUnitSporeComparison.scala
@@ -1,0 +1,46 @@
+package scala.spores
+package run
+package basic
+
+import scala.spores.run.basic
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class NullaryUnitSporeComparison {
+
+
+
+  /**
+    * Similar to pTTCapture(), but spores are nested.
+    */
+  @Test
+  def nestedPTTCapture(): Unit = {
+    val s = spore{
+      (_: Unit) => {
+        spore {
+          (_: Unit) => ()
+        }
+        ()
+      }
+    }
+  }
+
+
+  /**
+    * same as nestedPTTCapture, but (_: Unit) => ... replaced with Nullary spore
+    */
+//  @Test
+//  def nestedPTTCaptureNullary(): Unit = {
+//    val s = spore{
+//      delayed {
+//        spore {
+//          (_: Unit) => ()
+//        }
+//        ()
+//      }
+//    }
+//  }
+}

--- a/spores-pickling/src/main/scala/scala/spores/Pickler.scala
+++ b/spores-pickling/src/main/scala/scala/spores/Pickler.scala
@@ -100,7 +100,10 @@ object SporePickler extends SimpleSporePicklerImpl {
           val tag3 = reader3.beginEntry()
           val result3 = capturedUnpickler.unpickle(tag3, reader3)
           reader3.endEntry()
-          sporeInst.captured = result3.asInstanceOf[sporeInst.Captured]
+
+          val capturedValField = clazz.getDeclaredField("captured")
+          capturedValField.setAccessible(true)
+          capturedValField.set(sporeInst, result3.asInstanceOf[sporeInst.Captured])
 
           sporeInst
         }
@@ -256,7 +259,10 @@ object SporePickler extends SimpleSporePicklerImpl {
           val tag3 = reader3.beginEntry()
           val result3 = capturedUnpickler.unpickle(tag3, reader3)
           reader3.endEntry()
-          sporeInst.captured = result3.asInstanceOf[sporeInst.Captured]
+
+          val capturedValField = clazz.getDeclaredField("captured")
+          capturedValField.setAccessible(true)
+          capturedValField.set(sporeInst, result3.asInstanceOf[sporeInst.Captured])
 
           sporeInst
         }
@@ -429,7 +435,9 @@ object SporePickler extends SimpleSporePicklerImpl {
               }
             }
             reader3.endEntry()
-            sporeWithEnvInst.captured = value.asInstanceOf[sporeWithEnvInst.Captured]
+            val capturedValField = clazz.getDeclaredField("captured")
+            capturedValField.setAccessible(true)
+            capturedValField.set(sporeWithEnvInst, value.asInstanceOf[sporeWithEnvInst.Captured])
           }
 
           sporeInst
@@ -486,7 +494,9 @@ object SporePickler extends SimpleSporePicklerImpl {
               }
             }
             reader3.endEntry()
-            sporeWithEnvInst.captured = value.asInstanceOf[sporeWithEnvInst.Captured]
+            val capturedValField = clazz.getDeclaredField("captured")
+            capturedValField.setAccessible(true)
+            capturedValField.set(sporeWithEnvInst, value.asInstanceOf[sporeWithEnvInst.Captured])
           }
 
           sporeInst
@@ -548,7 +558,10 @@ object SporePickler extends SimpleSporePicklerImpl {
             }
           }
           reader3.endEntry()
-          sporeInst.captured = value.asInstanceOf[sporeInst.Captured]
+          val capturedValField = clazz.getDeclaredField("captured")
+          capturedValField.setAccessible(true)
+          capturedValField.set(sporeInst, value.asInstanceOf[sporeInst.Captured])
+
           sporeInst
         }
       }
@@ -613,7 +626,10 @@ object SporePickler extends SimpleSporePicklerImpl {
             }
           }
           reader3.endEntry()
-          sporeInst.captured = value.asInstanceOf[sporeInst.Captured]
+          val capturedValField = clazz.getDeclaredField("captured")
+          capturedValField.setAccessible(true)
+          capturedValField.set(sporeInst, value.asInstanceOf[sporeInst.Captured])
+
           sporeInst
         }
       }
@@ -669,7 +685,9 @@ object SporePickler extends SimpleSporePicklerImpl {
               }
             }
             reader3.endEntry()
-            sporeWithEnvInst.captured = value.asInstanceOf[sporeWithEnvInst.Captured]
+            val capturedValField = clazz.getDeclaredField("captured")
+            capturedValField.setAccessible(true)
+            capturedValField.set(sporeWithEnvInst, value.asInstanceOf[sporeWithEnvInst.Captured])
           }
 
           sporeInst


### PR DESCRIPTION
* wrote a custom Transformer to correctly transform path-dependent types
that depend on captured variables and function parameters. The changes
are: method transformTypes in MacroImpl, calls to the method in check,
check2 and checkNullary. The rationale for these changes are the tests
pTTParameterCapture, pTTCapturedCapture in run.basic.Basic.

* changed the spore structure so that captured values are 'val'
rather than 'var. With these changes, path-dependent types can be formed
with the captured values. Test pTTCapturedCapture shows the need for this.
The 'captured' value is now provided as a constructor argument.
The code generated by check, check2, checkNullary has changed.
spores-pickling had to be changed to set 'captured' by reflection to