### PR TITLE
Made the following changes to Spores: (issues fixed)

### DIFF
--- a/core/src/main/scala/scala/spores/Spore.scala
+++ b/core/src/main/scala/scala/spores/Spore.scala
@@ -33,7 +33,7 @@ trait NullarySporeWithEnv[+R] extends NullarySpore[R] {
    *  If the Spore captures multiple variables, this field
    *  stores a tuple.
    */
-  var captured: Captured = _
+  val captured: Captured //= _
 
 }
 
@@ -62,7 +62,7 @@ trait SporeWithEnv[-T, +R] extends Spore[T, R] {
    *  If the Spore captures multiple variables, this field
    *  stores a tuple.
    */
-  var captured: Captured = _
+  val captured: Captured // = _
 
 }
 
@@ -91,7 +91,7 @@ trait Spore2WithEnv[-T1, -T2, +R] extends Spore2[T1, T2, R] {
    *  If the Spore captures multiple variables, this field
    *  stores a tuple.
    */
-  var captured: Captured = _
+  val captured: Captured // = _
 
 }
 
@@ -120,7 +120,7 @@ trait Spore3WithEnv[-T1, -T2, -T3, +R] extends Spore3[T1, T2, T3, R] {
    *  If the Spore captures multiple variables, this field
    *  stores a tuple.
    */
-  var captured: Captured = _
+  val captured: Captured // = _
 
 }
 

--- a/core/src/main/scala/scala/spores/package.scala
+++ b/core/src/main/scala/scala/spores/package.scala
@@ -97,13 +97,13 @@ package object spores {
             case vd @ ValDef(mods, name, tpt, rhs) =>
               List(vd.symbol -> tpt.tpe)
             case td @ TypeDef(mods, name, tparams, rhs) =>
-              println(s"found type def $name with rhs: $rhs")
+              debug(s"found type def $name with rhs: $rhs")
               if (name.toString == "Constraint") {
                 rhs match {
                   case tpt @ TypeTree() =>
-                    println(s"found TypeTree, tpe: ${tpt.tpe}")
+                    debug(s"found TypeTree, tpe: ${tpt.tpe}")
                   case _ =>
-                    println(s"rhs is something else: ${rhs.getClass}")
+                    debug(s"rhs is something else: ${rhs.getClass}")
                 }
               }
               List()
@@ -170,7 +170,7 @@ package object spores {
 
     // check Spore constraints
     val tpes = checkTc(c)(fun.tree)
-    println("captured types: " + tpes)
+    debug("captured types: " + tpes)
 
     reify {
       val f = fun.splice

--- a/core/src/test/scala/scala/spores/run/basic/Basic.scala
+++ b/core/src/test/scala/scala/spores/run/basic/Basic.scala
@@ -23,11 +23,148 @@ package somepackage {
   }
 }
 
+
+
+abstract class X { def g(f: Int => Unit) : Unit}
+abstract class TestCl[T] {val x : X}
+
+
 @RunWith(classOf[JUnit4])
 class BasicSpec {
+
+
+  /**
+    * Test the following:
+    * spore has variable a
+    * a is part of PTT in spore
+    * PTT needs to be correct, when 'a' is changed into x$macro$n,
+    * PTT must change.
+    *
+    * Expansion with SporeConv.sporeConv is optional.
+    */
+  @Test
+  def pTTParameterCapture(): Unit = {
+
+    abstract class A {
+      self =>
+      type B
+      val t: self.B
+      def f(x: self.B) = {}
+    }
+
+    val s = spore{
+      val y = 5
+      (a: A) => {
+        val k: a.B = a.t
+        a.f(k)
+      }
+    }
+  }
+
+  /**
+    * Same as pTTParameterCapture, but
+    * the path-dependent type comes from a captured variable,
+    * not from the parameter
+    */
+  @Test
+  def pTTCapturedCapture(): Unit = {
+
+    abstract class A {
+      self =>
+      type B
+      val t: self.B
+      def f(x: self.B) = {}
+    }
+
+    val s = spore{
+      (a: A) => {
+        val s2 = spore {
+          val na = a
+          (_: Unit) => {
+            val k: na.B = na.t
+            na.f(k)
+          }
+        }
+      }
+    }
+  }
+
+  /**
+    * Same as pTTCapturedCapture, but with nullary spores (more code coverage)
+    */
+  @Test
+  def pTTCapturedCaptureNullary(): Unit = {
+
+    abstract class A {
+      self =>
+      type B
+      val t: self.B
+      def f(x: self.B) = {}
+    }
+
+    val s = spore{
+      (a: A) => {
+        val s2 = spore {
+          val na = a
+          delayed {
+            val k: na.B = na.t
+            na.f(k)
+          }
+        }
+      }
+    }
+  }
+
+  /**
+    * Similar to pTTCapture(), but spores are nested.
+    */
+  @Test
+  def nestedPTTCapture(): Unit = {
+
+    abstract class A {
+      self =>
+      type B
+      val t: self.B
+      def f(x: self.B) = {}
+    }
+
+    val s = spore{
+      val y = 5
+      (_: Unit) => {
+        spore {
+          val y = 5
+          (a: A) => {
+            val k: a.B = a.t
+            a.f(k)
+          }
+        }
+        println()
+      }
+    }
+  }
+
+
+
+  @Test
+  def sporeWithAnonClasses(): Unit = {
+
+    class B {self => type C}
+
+    val s = spore{
+      (x: B) => {
+        final class anon { type D = x.C }
+        val y = new anon
+      }
+    }
+  }
+
+
+
+
   @Test
   def `simple spore transformation`(): Unit = {
     val v1 = 10
+    val v2 = 20
     val s: Spore[Int, String] = spore {
       val c1 = v1
       (x: Int) => s"arg: $x, c1: $c1"
@@ -66,6 +203,66 @@ class BasicSpec {
     }
     assert(s(2).contains("C"))
   }
+
+  // This is to test that path-dependent types in which captured arguments are part of the path are
+  // transformed correctly.
+  @Test
+  def pathDependentTypes(): Unit = {
+    class A {
+      type B
+      def f(x: B) = println(x)
+    }
+
+    val s = spore {
+      (x: A) => {
+        x.f(null.asInstanceOf[x.B])
+      }
+    }
+  }
+
+  // This is to test that path-dependent types in which captured arguments are part of the path are
+  // transformed correctly.
+  @Test
+  def pathDependentTypesWithCapture(): Unit = {
+    class A {
+      type B
+      def f(x: B) = println(x)
+    }
+
+    val y = 10
+
+    val s = spore {
+      val yy = y
+      (x: A) => {
+        x.f(null.asInstanceOf[x.B])
+      }
+    }
+  }
+
+  // This is to test that path-dependent types in which captured arguments are part of the path are
+  // transformed correctly.
+  @Test
+  def pathDependentTypesWithNestedSpores(): Unit = {
+    abstract class A {
+      val c: {type B}
+      def f(s: Spore[A, Unit]) = s(this)
+      def g(x: c.B) = println(x)
+    }
+
+    val s = spore {
+      (a: A) => {
+        a.f(spore {
+          val cap_a = a
+          (a1: A) => {
+            val cap_cap_a = cap_a
+            a1.g(null.asInstanceOf[a1.c.B])
+          }
+        })
+      }
+    }
+  }
+
+
 }
 
 

--- a/spores-pickling/src/main/scala/scala/spores/Pickler.scala
+++ b/spores-pickling/src/main/scala/scala/spores/Pickler.scala
@@ -100,7 +100,10 @@ object SporePickler extends SimpleSporePicklerImpl {
           val tag3 = reader3.beginEntry()
           val result3 = capturedUnpickler.unpickle(tag3, reader3)
           reader3.endEntry()
-          sporeInst.captured = result3.asInstanceOf[sporeInst.Captured]
+
+          val capturedValField = clazz.getDeclaredField("captured")
+          capturedValField.setAccessible(true)
+          capturedValField.set(sporeInst, result3.asInstanceOf[sporeInst.Captured])
 
           sporeInst
         }
@@ -256,7 +259,10 @@ object SporePickler extends SimpleSporePicklerImpl {
           val tag3 = reader3.beginEntry()
           val result3 = capturedUnpickler.unpickle(tag3, reader3)
           reader3.endEntry()
-          sporeInst.captured = result3.asInstanceOf[sporeInst.Captured]
+
+          val capturedValField = clazz.getDeclaredField("captured")
+          capturedValField.setAccessible(true)
+          capturedValField.set(sporeInst, result3.asInstanceOf[sporeInst.Captured])
 
           sporeInst
         }
@@ -429,7 +435,9 @@ object SporePickler extends SimpleSporePicklerImpl {
               }
             }
             reader3.endEntry()
-            sporeWithEnvInst.captured = value.asInstanceOf[sporeWithEnvInst.Captured]
+            val capturedValField = clazz.getDeclaredField("captured")
+            capturedValField.setAccessible(true)
+            capturedValField.set(sporeWithEnvInst, value.asInstanceOf[sporeWithEnvInst.Captured])
           }
 
           sporeInst
@@ -486,7 +494,9 @@ object SporePickler extends SimpleSporePicklerImpl {
               }
             }
             reader3.endEntry()
-            sporeWithEnvInst.captured = value.asInstanceOf[sporeWithEnvInst.Captured]
+            val capturedValField = clazz.getDeclaredField("captured")
+            capturedValField.setAccessible(true)
+            capturedValField.set(sporeWithEnvInst, value.asInstanceOf[sporeWithEnvInst.Captured])
           }
 
           sporeInst
@@ -548,7 +558,10 @@ object SporePickler extends SimpleSporePicklerImpl {
             }
           }
           reader3.endEntry()
-          sporeInst.captured = value.asInstanceOf[sporeInst.Captured]
+          val capturedValField = clazz.getDeclaredField("captured")
+          capturedValField.setAccessible(true)
+          capturedValField.set(sporeInst, value.asInstanceOf[sporeInst.Captured])
+
           sporeInst
         }
       }
@@ -613,7 +626,10 @@ object SporePickler extends SimpleSporePicklerImpl {
             }
           }
           reader3.endEntry()
-          sporeInst.captured = value.asInstanceOf[sporeInst.Captured]
+          val capturedValField = clazz.getDeclaredField("captured")
+          capturedValField.setAccessible(true)
+          capturedValField.set(sporeInst, value.asInstanceOf[sporeInst.Captured])
+
           sporeInst
         }
       }
@@ -669,7 +685,9 @@ object SporePickler extends SimpleSporePicklerImpl {
               }
             }
             reader3.endEntry()
-            sporeWithEnvInst.captured = value.asInstanceOf[sporeWithEnvInst.Captured]
+            val capturedValField = clazz.getDeclaredField("captured")
+            capturedValField.setAccessible(true)
+            capturedValField.set(sporeWithEnvInst, value.asInstanceOf[sporeWithEnvInst.Captured])
           }
 
           sporeInst


### PR DESCRIPTION
*   Wrote a custom Transformer to correctly transform path-dependen types
    that depend on captured variables and function parameters. The changes
    are: method transformTypes in MacroImpl, calls to the method in check,
    check2 and checkNullary. The rationale for these changes are the tests
    pTTParameterCapture, pTTCapturedCapture in run.basic.Basic.

*   Changed the spore structure so that captured values are 'val'
    rather than 'var. With these changes, path-dependent types can be formed
    with the captured values. Test pTTCapturedCapture shows the need for this.
    The 'captured' value is now provided as a constructor argument.
    The code generated by check, check2, checkNullary has changed.
    spores-pickling had to be changed to set 'captured' by reflection to

*   Changes from [last pull request](https://github.com/heathermiller/spores/pull/25):
    1. removed links to external projects
    2. removed comparison with "showRaw(...)"
    3. changed transformTypes() to not have "string -> tree" mappings and insted
       use the alredy provided "Symbol -> Tree" map.